### PR TITLE
add log to log file and adjust the order of the  vulnerabilities from  clair checking

### DIFF
--- a/worker/ci/manager.go
+++ b/worker/ci/manager.go
@@ -103,7 +103,7 @@ func (cm *Manager) ExecBuild(r *runner.Build) error {
 	return nil
 }
 
-// ExecBuild executes publish image to registry.
+// ExecPublish executes publish image to registry.
 func (cm *Manager) ExecPublish(r *runner.Build) error {
 	log.Info("About to run publish event.")
 
@@ -147,12 +147,14 @@ func (cm *Manager) Parse(event *api.Event) (*parser.Tree, error) {
 		directFilePath = fmt.Sprintf("%s/%s", contextDir, yamlName)
 	}
 	if osutil.IsFileExists(directFilePath) != true {
+		fmt.Fprintf(steplog.Output, "Error: %v\n", errYaml)
 		return nil, errYaml
 	}
 
 	// Fetch and parse caicloud.yml from the repo.
 	tree, err := fetchAndParseYaml(directFilePath)
 	if err != nil {
+		fmt.Fprintf(steplog.Output, "Error: %v\n", err)
 		return nil, err
 	}
 	return tree, nil

--- a/worker/clair/clair.go
+++ b/worker/clair/clair.go
@@ -125,7 +125,7 @@ func AnalysisImage(dockerManager *docker.Manager,
 }
 
 func compareSeverity(severity1 Serverity, severity2 Serverity) bool {
-	return SeverityWeight[severity1] < SeverityWeight[severity2]
+	return SeverityWeight[severity1] > SeverityWeight[severity2]
 }
 
 // Len realize function of interface sort


### PR DESCRIPTION
1、 add log in log file when the specified  caicloud.yaml is not exsited 
2、 adjust the order of the  vulnerabilities from  clair checking 