### PR TITLE
feat(server): set default name when name empty in creating pipeline record

### DIFF
--- a/api/conversion/conversion.go
+++ b/api/conversion/conversion.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/caicloud/cyclone/api"
 	newapi "github.com/caicloud/cyclone/pkg/api"
-	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -208,11 +207,7 @@ func ConvertPipelineParamsToVersion(performParams *newapi.PipelinePerformParams)
 	stagesStr := strings.Join(performParams.Stages, ",")
 	version.Operation = api.VersionOperation(strings.Replace(stagesStr, "imageRelease", "publish", 1))
 
-	if performParams.Name != "" {
-		version.Name = performParams.Name
-	} else {
-		version.Name = bson.NewObjectId().Hex()
-	}
+	version.Name = performParams.Name
 
 	if performParams.CreateSCMTag {
 		version.Operator = api.APIOperator

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -193,6 +193,8 @@ func (worker *Worker) createVersion(vcsManager *vcs.Manager, event *api.Event) {
 		return
 	}
 
+	formatVersionName(event)
+
 	setImageNameAndTag(dockerManager, event)
 
 	replaceDockerfile(event, destDir)
@@ -345,6 +347,14 @@ func setEventFailStatus(event *api.Event, ErrorMessage string) {
 	logdog.Error("Operation failed", logdog.Fields{"event": event})
 }
 
+// formatVersionName replace the random name with default name '$commitID[:7]-$createTime' when name empty in create version
+func formatVersionName(event *api.Event) {
+	if event.Version.Name == "" && event.Version.Commit != "" {
+		// report to server in sendEvent
+		event.Version.Name = fmt.Sprintf("%s-%s", event.Version.Commit[:7], event.Version.CreateTime.Format("060102150405"))
+	}
+}
+
 // setImageNameAndTag sets the image name and tag name of the event.
 func setImageNameAndTag(dockerManager *docker.Manager, event *api.Event) {
 
@@ -378,4 +388,3 @@ func setImageNameAndTag(dockerManager *docker.Manager, event *api.Event) {
 	event.Data["image-name"] = imageName
 	event.Data["tag-name"] = tagName
 }
-


### PR DESCRIPTION
**Changes**
   
   - [ ] feature

set '$commitID[:7]-$createTime' instead of random string as default pipelineRecord.name 

**Reviewers**

  - @supereagle please review

    
**Checklist**
   
   - [x] Rebased/mergable
   - [ ] Tests pass
   - [ ] Issue/task done
