### PR TITLE
fix(#252;#258): ensure terminating worker with error before delete fail event

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -152,14 +152,15 @@ func createServiceHandler(event *api.Event) error {
 		return err
 	}
 
+	// set worker info to event
+	event.Worker = worker.GetWorkerInfo()
+
 	err = worker.Do()
 	if err != nil {
 		logdog.Error("run worker err", logdog.Fields{"err": err})
 		return err
 	}
 
-	// set worker info to event
-	event.Worker = worker.GetWorkerInfo()
 	SaveEventToEtcd(event)
 	go CheckWorkerTimeout(event)
 


### PR DESCRIPTION
## Fixes [ISSUE-252](https://github.com/caicloud/cyclone/issues/252)  [ISSUE-258](https://github.com/caicloud/cyclone/issues/258)

**Changes**
   
  - [x] get workerInfo before worker.Do()

**Reviewers**

  - [ ] @supereagle  please review
    
**Checklist**
   
   - [x] Rebased/mergable
   - [x] Tests pass
   - [x] Issue/task done


