### PR TITLE
fix(309): keep the license itself untouched

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 The Kubernetes Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Fixes #309

The Apache 2.0 license includes an Appendix about how to apply the
license terms to files. We should not modify the license file and
instead should tell people what to do as far as dates, etc in the devel
guides.

**Changes**

  - [x] keep the license itself untouched

xref:  [LICENSE: revert modifications to Apache license](
https://github.com/kubernetes/kubernetes/commit/d30db1f9a915aa95402e1190461469a1889d92be)