### PR TITLE
feat(#319): add registry auth info into Docker manager

### DIFF
--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -36,10 +36,12 @@ const (
 // The Docker client can be direclty used for some functions not provided by this manager.
 type DockerManager struct {
 	// Client represets the Docker client.
-	Client *docker_client.Client
+	Client     *docker_client.Client
+	EndPoint   string
+	AuthConfig *docker_client.AuthConfiguration
 }
 
-func NewDockerManager(endpoint string) (*DockerManager, error) {
+func NewDockerManager(endpoint, registryServer, registryUsername, registryPassword string) (*DockerManager, error) {
 	if len(strings.TrimSpace(endpoint)) == 0 {
 		endpoint = defaultEndpoint
 	}
@@ -54,7 +56,13 @@ func NewDockerManager(endpoint string) (*DockerManager, error) {
 	}
 
 	return &DockerManager{
-		Client: client,
+		Client:   client,
+		EndPoint: endpoint,
+		AuthConfig: &docker_client.AuthConfiguration{
+			ServerAddress: registryServer,
+			Username:      registryUsername,
+			Password:      registryPassword,
+		},
 	}, nil
 }
 
@@ -76,9 +84,12 @@ func (dm *DockerManager) StartContainer(options docker_client.CreateContainerOpt
 
 // ExecOptions specify parameters to the ExecInContainer function.
 type ExecOptions struct {
-	Cmd       []string
-	Container string
-	User      string
+	AttachStdin  bool
+	AttachStdout bool
+	AttachStderr bool
+	Cmd          []string
+	Container    string
+	User         string
 
 	// InputStream  io.Reader
 	OutputStream io.Writer


### PR DESCRIPTION
**What this PR does / why we need it**:

Add registry auth info into Docker manager to support pushing and pulling images from registry.

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes partially #319

**Special notes for your reviewer**:

/cc @bbbmj 

**Release note**:

```release-note
NONE
```

