### PR TITLE
feat(#308): refactor worker to run based on pipeline config instead of caicloud.yaml

### DIFF
--- a/cmd/worker/options.go
+++ b/cmd/worker/options.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"github.com/caicloud/cyclone/cloud"
-	"github.com/caicloud/cyclone/worker"
 	"gopkg.in/urfave/cli.v1"
+
+	"github.com/caicloud/cyclone/cloud"
+	"github.com/caicloud/cyclone/pkg/worker"
+	"github.com/caicloud/cyclone/pkg/worker/cycloneserver"
 )
 
 // WorkerOptions ...
@@ -28,7 +30,10 @@ func (opts *WorkerOptions) AddFlags(app *cli.App) {
 
 // NewWorker returns a new APIServer with config
 func (opts *WorkerOptions) NewWorker() *worker.Worker {
+	client := cycloneserver.NewClient(opts.WorkerEnvs.CycloneServer)
+
 	s := &worker.Worker{
+		Client: client,
 		Envs:   opts.WorkerEnvs,
 		Config: opts.Config,
 	}

--- a/pkg/worker/cycloneserver/client.go
+++ b/pkg/worker/cycloneserver/client.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cycloneserver
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/gorilla/websocket"
+
+	"github.com/caicloud/cyclone/pkg/api"
+	. "github.com/caicloud/cyclone/pkg/util/http/errors"
+	websocketutil "github.com/caicloud/cyclone/pkg/util/websocket"
+)
+
+const (
+	cycloneAPIVersion = "/api/v1"
+
+	apiPathForEvent     = "/events/%s"
+	apiPathForLogStream = "/projects/%s/pipelines/%s/records/%s/stagelogstream"
+)
+
+type CycloneServerClient interface {
+	GetEvent(id string) (*api.Event, error)
+	PushLogStream(project, pipeline, recordID string, stage api.PipelineStageName, filePath string) error
+}
+
+type client struct {
+	baseURL string
+	client  *http.Client
+}
+
+func NewClient(cycloneServer string) CycloneServerClient {
+	baseURL := strings.TrimRight(cycloneServer, "/")
+	if !strings.Contains(baseURL, "://") {
+		baseURL = "http://" + baseURL
+	}
+
+	return &client{
+		baseURL: baseURL,
+		client:  http.DefaultClient,
+	}
+}
+
+// do sends the request to Cyclone and returns an HTTP response.
+func (c *client) do(method, relativePath string, bodyObject interface{}) (*http.Response, error) {
+	url := c.baseURL + cycloneAPIVersion + relativePath
+	log.Infof("Request for Cyclone server: %s %s", method, url)
+
+	var body io.Reader
+	if bodyObject != nil {
+		bodyBytes, err := json.Marshal(bodyObject)
+		if err != nil {
+			return nil, err
+		}
+
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Errorf(err.Error())
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *client) GetEvent(id string) (*api.Event, error) {
+	path := fmt.Sprintf(apiPathForEvent, id)
+	resp, err := c.do(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, ErrorUnknownInternal.Format(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, ErrorUnknownInternal.Format(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 == 2 {
+		log.Infof("Event %s is got from Cyclone server", id)
+		event := &api.Event{}
+		if err := json.Unmarshal(body, event); err != nil {
+			log.Errorf("Fail to unmarshal event %s as %s", id, err.Error())
+			return nil, err
+		}
+
+		return event, nil
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrorContentNotFound.Format(fmt.Sprintf("event %s", id))
+	}
+
+	log.Errorf("Get event %s from Cyclone server with error %s", id, body)
+	return nil, ErrorUnknownInternal.Format(body)
+}
+
+func (c *client) PushLogStream(project, pipeline, recordID string, stage api.PipelineStageName, filePath string) error {
+	path := fmt.Sprintf(apiPathForLogStream, project, pipeline, recordID)
+	log.Infof("Path: %s", path)
+
+	host := strings.TrimPrefix(c.baseURL, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	requestUrl := url.URL{
+		Host:     host,
+		Path:     cycloneAPIVersion + path,
+		RawQuery: fmt.Sprintf("stage=%s", stage),
+		Scheme:   "ws",
+	}
+
+	header := http.Header{
+		"Connection":            []string{"Upgrade"},
+		"Upgrade":               []string{"websocket"},
+		"Host":                  []string{host},
+		"Sec-Websocket-Key":     []string{"SGVsbG8sIHdvcmxkIQ=="},
+		"Sec-Websocket-Version": []string{"13"},
+	}
+	filteredHeader := websocketutil.FilterHeader(header)
+
+	ws, _, err := websocket.DefaultDialer.Dial(requestUrl.String(), filteredHeader)
+	if err != nil {
+		log.Errorf("Fail to new the WebSocket connection as %s", err.Error())
+		return err
+	}
+	defer ws.Close()
+
+	return watchLogs(ws, filePath)
+}
+
+func watchLogs(ws *websocket.Conn, filePath string) error {
+	logFile, err := os.Open(filePath)
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
+	defer logFile.Close()
+
+	buf := bufio.NewReader(logFile)
+	for {
+		line, errRead := buf.ReadBytes('\n')
+		if errRead != nil {
+			if errRead == io.EOF {
+				continue
+			}
+			log.Errorf("watch log file errs: %v", errRead)
+			ws.WriteMessage(websocket.CloseMessage, []byte(errRead.Error()))
+			return errRead
+		}
+		fmt.Printf("%s", line)
+		ws.WriteMessage(websocket.TextMessage, line)
+	}
+}

--- a/pkg/worker/options.go
+++ b/pkg/worker/options.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"github.com/caicloud/cyclone/cloud"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+// Config contains all options(config) for worker
+type Config struct {
+	ID         string
+	DockerHost string
+}
+
+// NewConfig returns a new worker config
+func NewConfig() *Config {
+	return &Config{
+		DockerHost: "unix:///var/run/docker.sock",
+	}
+}
+
+// AddFlags adds flags to cli.App
+func (opts *Config) AddFlags(app *cli.App) {
+
+	flags := []cli.Flag{
+		cli.StringFlag{
+			Name:        "id",
+			Usage:       "worker event id",
+			EnvVar:      cloud.WorkerEventID,
+			Destination: &opts.ID,
+		},
+		cli.StringFlag{
+			Name:        "docker-host",
+			Value:       "unix:///var/run/docker.sock",
+			Usage:       "worker used docker host",
+			EnvVar:      "DOCKER_HOST",
+			Destination: &opts.DockerHost,
+		},
+	}
+
+	app.Flags = append(app.Flags, flags...)
+
+}

--- a/pkg/worker/scm/manager.go
+++ b/pkg/worker/scm/manager.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scm
+
+import (
+	"encoding/base64"
+	"fmt"
+	neturl "net/url"
+	"strings"
+
+	"github.com/zoumo/logdog"
+
+	"github.com/caicloud/cyclone/pkg/api"
+	"github.com/caicloud/cyclone/pkg/pathutil"
+)
+
+const (
+	// cloneDir represents the dir which the repo clone to.
+	// cloneDir = "/root/code"
+	cloneDir = "/tmp/code"
+)
+
+// scmProviders represents the set of SCM providers.
+var scmProviders map[api.SCMType]SCMProvider
+
+type SCMProvider interface {
+	Clone(url, destPath string) (string, error)
+	GetTagCommit(repoPath string, tag string) (string, error)
+}
+
+func init() {
+	scmProviders = make(map[api.SCMType]SCMProvider)
+}
+
+// RegisterProvider registers SCM providers.
+func RegisterProvider(scmType api.SCMType, provider SCMProvider) error {
+	if _, ok := scmProviders[scmType]; ok {
+		return fmt.Errorf("SCM provider %s already exists", scmType)
+	}
+
+	scmProviders[scmType] = provider
+	return nil
+}
+
+// GetSCMProvider gets the SCM provider by the type.
+func GetSCMProvider(scmType api.SCMType) (SCMProvider, error) {
+	provider, ok := scmProviders[scmType]
+	if !ok {
+		return nil, fmt.Errorf("unsupported SCM type %s", scmType)
+	}
+
+	return provider, nil
+}
+
+// GetCloneDir returns the clone dir.
+func GetCloneDir() string {
+	return cloneDir
+}
+
+func CloneRepo(token string, codeSource *api.CodeSource) (string, error) {
+	destPath := GetCloneDir()
+	if err := pathutil.EnsureParentDir(destPath, 0750); err != nil {
+		return "", fmt.Errorf("Unable to create parent directory for %s: %v\n", destPath, err)
+	}
+
+	scmType := codeSource.Type
+	p, err := GetSCMProvider(scmType)
+	if err != nil {
+		logdog.Error(err.Error())
+		return "", err
+	}
+
+	url, err := getAuthURL(token, codeSource)
+	if err != nil {
+		return "", err
+	}
+
+	logs, err := p.Clone(url, destPath)
+	if err != nil {
+		return "", err
+	}
+
+	return logs, err
+}
+
+func getGitSource(codeSource *api.CodeSource) (*api.GitSource, error) {
+	scmType := codeSource.Type
+	var gitSource *api.GitSource
+	switch scmType {
+	case api.GitHub:
+		gitSource = codeSource.GitHub
+	case api.GitLab:
+		gitSource = codeSource.GitLab
+	case api.SVN:
+		return nil, fmt.Errorf("SCM type SVN is not implemented")
+	default:
+		return nil, fmt.Errorf("SCM type %s is not supported", scmType)
+	}
+
+	return gitSource, nil
+}
+
+// getAuthURL rebuilds url with auth token or username and password
+// for private git repository
+func getAuthURL(token string, codeSource *api.CodeSource) (string, error) {
+	scmType := codeSource.Type
+	if scmType == api.GitLab && token != "" {
+		token = "oauth2:" + token
+	}
+
+	gitSource, err := getGitSource(codeSource)
+	if err != nil {
+		logdog.Errorf(err.Error())
+		return "", err
+	}
+
+	// rebuild token
+	if token == "" && gitSource.Username != "" && gitSource.Password != "" {
+		token = queryEscape(gitSource.Username, gitSource.Password)
+	}
+
+	// insert token
+
+	url := gitSource.Url
+	if scmType == api.GitHub || scmType == api.GitLab {
+		position := -1
+		if strings.HasPrefix(url, "http://") {
+			position = len("http://")
+		} else if strings.HasPrefix(url, "https://") {
+			position = len("https://")
+		}
+		if position > 0 {
+			url = insert(url, token+"@", position)
+		}
+	}
+
+	return url, nil
+}
+
+// This function is used to insert the string "insertion" into the "url"
+// at the "index" postiion
+func insert(url, insertion string, index int) string {
+	result := make([]byte, len(url)+len(insertion))
+	slice := []byte(url)
+	at := copy(result, slice[:index])
+	at += copy(result[at:], insertion)
+	copy(result[at:], slice[index:])
+	return string(result)
+}
+
+// queryEscape escapes the string so it can be safely placed
+// inside a URL query.
+func queryEscape(username, pwdBase64 string) string {
+	var pwd string
+	pwdB, err := base64.StdEncoding.DecodeString(pwdBase64)
+	if err != nil {
+		pwd = pwdBase64
+	} else {
+		pwd = string(pwdB)
+	}
+	return neturl.QueryEscape(username) + ":" + neturl.QueryEscape(pwd)
+}

--- a/pkg/worker/scm/provider/git.go
+++ b/pkg/worker/scm/provider/git.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"path"
+	"strings"
+
+	log "github.com/zoumo/logdog"
+
+	"github.com/caicloud/cyclone/pkg/api"
+	"github.com/caicloud/cyclone/pkg/executil"
+	"github.com/caicloud/cyclone/pkg/worker/scm"
+)
+
+// Git is the type for git provider.
+type Git struct{}
+
+func init() {
+	if err := scm.RegisterProvider(api.GitHub, new(Git)); err != nil {
+		log.Error(err)
+	}
+
+	if err := scm.RegisterProvider(api.GitLab, new(Git)); err != nil {
+		log.Error(err)
+	}
+}
+
+func (g *Git) Clone(url, destPath string) (string, error) {
+	log.Info("About to clone git repository.", log.Fields{"url": url, "destPath": destPath})
+
+	base := path.Base(destPath)
+	dir := path.Dir(destPath)
+	args := []string{"clone", url, base}
+
+	output, err := executil.RunInDir(dir, "git", args...)
+
+	if err != nil {
+		log.Error("Error when clone", log.Fields{"error": err})
+	} else {
+		log.Info("Successfully cloned git repository.", log.Fields{"url": url, "destPath": destPath})
+	}
+	return string(output), err
+}
+
+// GetTagCommit implements VCS interface.
+func (g *Git) GetTagCommit(repoPath string, tag string) (string, error) {
+	args := []string{"rev-list", "-n", "1", tag}
+	output, err := executil.RunInDir(repoPath, "git", args...)
+
+	return strings.Trim(string(output), "\n"), err
+}

--- a/pkg/worker/stage/stage.go
+++ b/pkg/worker/stage/stage.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stage
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	docker_client "github.com/fsouza/go-dockerclient"
+	log "github.com/golang/glog"
+	"github.com/zoumo/logdog"
+
+	"github.com/caicloud/cyclone/pkg/api"
+	"github.com/caicloud/cyclone/pkg/docker"
+	"github.com/caicloud/cyclone/pkg/pathutil"
+	"github.com/caicloud/cyclone/pkg/worker/cycloneserver"
+	"github.com/caicloud/cyclone/pkg/worker/scm"
+	"github.com/caicloud/cyclone/worker/ci/runner"
+)
+
+// logFileNameTemplate ...
+const logFileNameTemplate = "/tmp/logs/%s.log"
+
+type StageManager interface {
+	SetRecordInfo(project, pipeline, recordID string)
+	ExecCodeCheckout(token string, stage *api.CodeCheckoutStage) error
+	ExecPackage(*api.BuilderImage, *api.UnitTestStage, *api.PackageStage) error
+	ExecImageBuild(stage *api.ImageBuildStage) ([]string, error)
+	ExecIntegrationTest(builtImages []string, stage *api.IntegrationTestStage) error
+	ExecImageRelease(builtImages []string, stage *api.ImageReleaseStage) error
+}
+
+type recordInfo struct {
+	project  string
+	pipeline string
+	recordID string
+}
+
+type stageManager struct {
+	recordInfo
+	dockerManager *docker.DockerManager
+	cycloneClient cycloneserver.CycloneServerClient
+}
+
+func NewStageManager(dockerManager *docker.DockerManager, cycloneClient cycloneserver.CycloneServerClient) StageManager {
+	err := pathutil.EnsureParentDir(logFileNameTemplate, os.ModePerm)
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+
+	return &stageManager{
+		dockerManager: dockerManager,
+		cycloneClient: cycloneClient,
+	}
+}
+
+func (sm *stageManager) SetRecordInfo(project, pipeline, recordID string) {
+	sm.project = project
+	sm.pipeline = pipeline
+	sm.recordID = recordID
+}
+
+func (sm *stageManager) ExecCodeCheckout(token string, stage *api.CodeCheckoutStage) error {
+	codeSource := stage.CodeSources[0]
+	scmProvider, err := scm.GetSCMProvider(codeSource.Type)
+	if err != nil {
+		log.Errorf("Fail to get SCM provider as %s", err.Error())
+		return err
+	}
+
+	cloneDir := scm.GetCloneDir()
+	logs, err := scm.CloneRepo(token, codeSource)
+	if err != nil {
+		logdog.Error(err.Error())
+		return err
+	}
+
+	fileName := fmt.Sprintf(logFileNameTemplate, api.CodeCheckoutStageName)
+	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	// Just one line of log, will add more detailed logs.
+	logFile.WriteString(logs)
+
+	go sm.cycloneClient.PushLogStream(sm.project, sm.pipeline, sm.recordID, api.CodeCheckoutStageName, fileName)
+
+	// Get commit ID
+	commitID, err := scmProvider.GetTagCommit(cloneDir, "master")
+	if err != nil {
+		return err
+	}
+
+	log.Infof("The commit id is %s", commitID)
+	return nil
+}
+
+func (sm *stageManager) ExecPackage(builderImage *api.BuilderImage, unitTestStage *api.UnitTestStage, packageStage *api.PackageStage) error {
+	// Trick: bind the docker sock file to container to support
+	// docker operation in the container.
+	enterpoint := []byte(sm.dockerManager.EndPoint)[7:]
+	log.Infof("enterpoint is %s", string(enterpoint))
+	pathenterpoint := fmt.Sprintf("%s:%s", string(enterpoint), "/var/run/docker.sock")
+
+	cloneDir := scm.GetCloneDir()
+	hostConfig := &docker_client.HostConfig{
+		Binds: []string{fmt.Sprintf("%s:%s", cloneDir, cloneDir), pathenterpoint},
+	}
+
+	// Start and run the container from builder image.
+	config := &docker_client.Config{
+		Image:      builderImage.Image,
+		Env:        convertEnvs(builderImage.EnvVars),
+		OpenStdin:  true, // Open stdin to keep the container running after starts.
+		WorkingDir: cloneDir,
+		// Entrypoint: []string{"/bin/sh", "-e", "-c"},
+	}
+
+	cco := docker_client.CreateContainerOptions{
+		Config:     config,
+		HostConfig: hostConfig,
+	}
+	cid, err := sm.dockerManager.StartContainer(cco)
+	if err != nil {
+		return err
+	}
+
+	// Execute unit test and package commands in the builder container.
+	// Run stage script in container
+	cmds := packageStage.Command
+	// Run the unit test commands before package commands if there is unit test stage.
+	if unitTestStage != nil {
+		cmds = append(unitTestStage.Command, cmds...)
+	}
+
+	fileName := fmt.Sprintf(logFileNameTemplate, api.PackageStageName)
+	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	go sm.cycloneClient.PushLogStream(sm.project, sm.pipeline, sm.recordID, api.PackageStageName, fileName)
+
+	eo := docker.ExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		Container:    cid,
+		OutputStream: logFile,
+		ErrorStream:  logFile,
+	}
+
+	// Run the commands one by one.
+	for _, cmd := range cmds {
+		eo.Cmd = strings.Split(cmd, " ")
+		err = sm.dockerManager.ExecInContainer(eo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Copy the build outputs if necessary.
+	// Only need to copy the outputs not in the current workspace. The outputs must be absolute path of files or folders.
+	for _, output := range packageStage.Outputs {
+		if err = runner.CopyFromContainer(sm.dockerManager.Client, cid, output, cloneDir+"/"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sm *stageManager) ExecImageBuild(stage *api.ImageBuildStage) ([]string, error) {
+	authConfig := sm.dockerManager.AuthConfig
+	authOpt := docker_client.AuthConfiguration{
+		Username: authConfig.Username,
+		Password: authConfig.Password,
+	}
+	authOpts := docker_client.AuthConfigurations{
+		Configs: make(map[string]docker_client.AuthConfiguration),
+	}
+	authOpts.Configs[authConfig.ServerAddress] = authOpt
+
+	fileName := fmt.Sprintf(logFileNameTemplate, api.ImageBuildStageName)
+	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+	if err != nil {
+		return nil, err
+	}
+	defer logFile.Close()
+
+	go sm.cycloneClient.PushLogStream(sm.project, sm.pipeline, sm.recordID, api.ImageBuildStageName, fileName)
+
+	opt := docker_client.BuildImageOptions{
+		AuthConfigs:    authOpts,
+		RmTmpContainer: true,
+		Memswap:        -1,
+		OutputStream:   logFile,
+	}
+
+	builtImages := []string{}
+	for _, buildInfo := range stage.BuildInfos {
+		dockerfilePath := "Dockerfile"
+		if buildInfo.DockerfilePath != "" {
+			dockerfilePath = buildInfo.DockerfilePath
+		}
+
+		opt.Name = buildInfo.ImageName
+		opt.Dockerfile = dockerfilePath
+		opt.ContextDir = scm.GetCloneDir()
+		if buildInfo.ContextDir != "" {
+			opt.ContextDir = opt.ContextDir + "/" + buildInfo.ContextDir
+		}
+
+		if err := sm.dockerManager.Client.BuildImage(opt); err != nil {
+			return nil, err
+		}
+		builtImages = append(builtImages, buildInfo.ImageName)
+	}
+
+	return builtImages, nil
+}
+
+func (sm *stageManager) ExecIntegrationTest(builtImages []string, stage *api.IntegrationTestStage) error {
+	log.Infof("Exec integration test stage for pipeline record %s/%s/%s", sm.project, sm.pipeline, sm.recordID)
+
+	// Start the services.
+	serviceNames, err := sm.StartServicesForIntegrationTest(stage.Services)
+	if err != nil {
+		return err
+	}
+
+	testConfig := stage.Config
+	var testImage string
+	for _, builtImage := range builtImages {
+		if strings.Contains(builtImage, testConfig.ImageName) {
+			testImage = builtImage
+			break
+		}
+	}
+
+	if testImage == "" {
+		err := fmt.Errorf("image %s in integration test config is not the built images %v", testConfig.ImageName, builtImages)
+		log.Error(err.Error())
+		return err
+	}
+
+	// Start the built image.
+	config := &docker_client.Config{
+		Image:      testImage,
+		Env:        convertEnvs(testConfig.EnvVars),
+		Entrypoint: testConfig.Command,
+	}
+
+	hostConfig := &docker_client.HostConfig{
+		Links: serviceNames,
+	}
+	cco := docker_client.CreateContainerOptions{
+		Config:     config,
+		HostConfig: hostConfig,
+	}
+	cid, err := sm.dockerManager.StartContainer(cco)
+	if err != nil {
+		return err
+	}
+
+	fileName := fmt.Sprintf(logFileNameTemplate, api.IntegrationTestStageName)
+	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	go sm.cycloneClient.PushLogStream(sm.project, sm.pipeline, sm.recordID, api.IntegrationTestStageName, fileName)
+
+	eo := docker.ExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		Container:    cid,
+		OutputStream: logFile,
+		ErrorStream:  logFile,
+	}
+
+	// Run the commands one by one.
+	for _, cmd := range testConfig.Command {
+		eo.Cmd = strings.Split(cmd, " ")
+		if err = sm.dockerManager.ExecInContainer(eo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sm *stageManager) StartServicesForIntegrationTest(services []api.Service) ([]string, error) {
+	var serviceNames []string
+	for _, svc := range services {
+		// Start and run the container from builder image.
+		config := &docker_client.Config{
+			Image:      svc.Image,
+			Env:        convertEnvs(svc.EnvVars),
+			Entrypoint: svc.Command,
+		}
+
+		cco := docker_client.CreateContainerOptions{
+			Name:   svc.Name,
+			Config: config,
+			// HostConfig: hostConfig,
+		}
+		_, err := sm.dockerManager.StartContainer(cco)
+		if err != nil {
+			return nil, err
+		}
+		serviceNames = append(serviceNames, svc.Name)
+	}
+
+	return serviceNames, nil
+}
+
+func (sm *stageManager) ExecImageRelease(builtImages []string, stage *api.ImageReleaseStage) error {
+	log.Infof("Exec image release stage for pipeline record %s/%s/%s", sm.project, sm.pipeline, sm.recordID)
+
+	policies := stage.ReleasePolicy
+	authConfig := sm.dockerManager.AuthConfig
+
+	fileName := fmt.Sprintf(logFileNameTemplate, api.ImageReleaseStageName)
+	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	go sm.cycloneClient.PushLogStream(sm.project, sm.pipeline, sm.recordID, api.ImageReleaseStageName, fileName)
+
+	authOpt := docker_client.AuthConfiguration{
+		Username: authConfig.Username,
+		Password: authConfig.Password,
+	}
+
+	for _, p := range policies {
+		for _, builtImage := range builtImages {
+			if strings.HasPrefix(builtImage, p.ImageName) {
+				log.Infof("Release the built image %s", builtImage)
+				imageParts := strings.Split(builtImage, ":")
+				opts := docker_client.PushImageOptions{
+					Name:         imageParts[0],
+					Tag:          imageParts[1],
+					OutputStream: logFile,
+				}
+
+				if err := sm.dockerManager.Client.PushImage(opts, authOpt); err != nil {
+					log.Errorf("Fail to release the built image %s as %s", builtImage, err.Error())
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func convertEnvs(envVars []api.EnvVar) []string {
+	var envs []string
+	for _, envVar := range envVars {
+		envs = append(envs, fmt.Sprintf("%s=%s", envVar.Name, envVar.Value))
+	}
+
+	return envs
+}
+
+func watchLogs(filePath string, lines chan []byte, stop chan bool) error {
+	log.Infof("watch log file: %s", filePath)
+	logFile, err := os.Open(filePath)
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
+	defer logFile.Close()
+
+	buf := bufio.NewReader(logFile)
+
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			log.Infoln("ticker")
+			lines <- []byte("hello abc")
+			line, errRead := buf.ReadBytes('\n')
+			if errRead != nil {
+				if errRead == io.EOF {
+					return nil
+				}
+				log.Errorf("watch log file as errs: %s", errRead.Error())
+				return errRead
+			}
+			log.Infof("log:%s", line)
+			lines <- line
+		case <-stop:
+			close(lines)
+			return nil
+		}
+	}
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2016 caicloud authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"github.com/zoumo/logdog"
+
+	"github.com/caicloud/cyclone/cloud"
+	"github.com/caicloud/cyclone/pkg/api"
+	"github.com/caicloud/cyclone/pkg/docker"
+	"github.com/caicloud/cyclone/pkg/worker/cycloneserver"
+	_ "github.com/caicloud/cyclone/pkg/worker/scm/provider"
+	"github.com/caicloud/cyclone/pkg/worker/stage"
+)
+
+// Worker ...
+type Worker struct {
+	Client cycloneserver.CycloneServerClient
+	Config *Config
+	Envs   *cloud.WorkerEnvs
+}
+
+// Run starts the worker
+func (worker *Worker) Run() error {
+	logdog.Info("worker start with", logdog.Fields{"config": worker.Config, "envs": worker.Envs})
+
+	// Get event for cyclone server
+	eventID := worker.Config.ID
+	event, err := worker.Client.GetEvent(eventID)
+	if err != nil {
+		logdog.Errorf("fail to get event %s as %s", eventID, err.Error())
+		return err
+	}
+	logdog.Info("get event success", logdog.Fields{"event": event})
+
+	// Handle event
+	logdog.Info("handleEvent ...")
+	worker.HandleEvent(event)
+
+	return nil
+}
+
+// Steps:
+// 1. Git clone code
+// 2. New Docker manager
+// 3. Run pipeline stages
+// 4. Create the tag in SCM
+func (worker *Worker) HandleEvent(event *api.Event) {
+	project := event.Project
+	pipeline := event.Pipeline
+	performParams := event.PipelineRecord.PerformParams
+	performStages := performParams.Stages
+	stageSet := convertPerformStageSet(performStages)
+	build := pipeline.Build
+
+	registryLocation := worker.Envs.RegistryLocation
+	registryUsername := worker.Envs.RegistryUsername
+	registryPassword := worker.Envs.RegistryPassword
+
+	dockerManager, err := docker.NewDockerManager(worker.Config.DockerHost, registryLocation, registryUsername, registryPassword)
+	if err != nil {
+		logdog.Error(err.Error())
+		return
+	}
+
+	// TODO(robin) Seperate unit test and package stage.
+	stageManager := stage.NewStageManager(dockerManager, worker.Client)
+	stageManager.SetRecordInfo(project.Name, pipeline.Name, event.ID)
+
+	// Execute the code checkout stage,
+	err = stageManager.ExecCodeCheckout(project.SCM.Token, build.Stages.CodeCheckout)
+	if err != nil {
+		logdog.Error(err.Error())
+		return
+	}
+
+	// Execute the package stage, this stage is required and can not be skipped.
+	err = stageManager.ExecPackage(build.BuilderImage, build.Stages.UnitTest, build.Stages.Package)
+	if err != nil {
+		logdog.Error(err.Error())
+		return
+	}
+
+	// The built images from image build stage.
+	var builtImages []string
+
+	// Execute the image build stage if necessary.
+	if _, ok := stageSet[api.ImageBuildStageName]; ok {
+		builtImages, err = stageManager.ExecImageBuild(build.Stages.ImageBuild)
+		if err != nil {
+			logdog.Error(err.Error())
+			return
+		}
+	}
+
+	// Execute the integration test stage if necessary.
+	if _, ok := stageSet[api.IntegrationTestStageName]; ok {
+		err = stageManager.ExecIntegrationTest(builtImages, build.Stages.IntegrationTest)
+		if err != nil {
+			logdog.Error(err.Error())
+			return
+		}
+	}
+
+	// Execute the integration test stage if necessary.
+	if _, ok := stageSet[api.ImageReleaseStageName]; ok {
+		err = stageManager.ExecImageRelease(builtImages, build.Stages.ImageRelease)
+		if err != nil {
+			logdog.Error(err.Error())
+			return
+		}
+	}
+
+	logdog.Info("success: ")
+}
+
+func convertPerformStageSet(stages []api.PipelineStageName) map[api.PipelineStageName]struct{} {
+	stageSet := make(map[api.PipelineStageName]struct{})
+	for _, stage := range stages {
+		stageSet[stage] = struct{}{}
+	}
+
+	return stageSet
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Run based on pipeline config instead of caicloud.yaml.

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #308

**Special notes for your reviewer**:

/cc @bbbmj 

**Release note**:

```release-note
Refactor worker: Run based on pipeline config instead of caicloud.yaml.
```