### PR TITLE
bug(db):make the member of GenenalStageStatus inline when stored in m…

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -295,8 +295,8 @@ type GeneralStageStatus struct {
 
 // CodeCheckoutStageStatus includes GeneralStageStatus and pipelineRecord version.
 type CodeCheckoutStageStatus struct {
-	GeneralStageStatus
-	Version map[string]CommitLog `bson:"version,omitempty" json:"version,omitempty" description:"version of the pipeline record"`
+	GeneralStageStatus `bson:",inline"`
+	Version            map[string]CommitLog `bson:"version,omitempty" json:"version,omitempty" description:"version of the pipeline record"`
 }
 
 type CommitLog struct {


### PR DESCRIPTION
…ongodb

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

make the member of GenenalStageStatus inline when stored in mongodb

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @supereagle 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
