### PR TITLE
Remove Go 1.7 and add Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ sudo: required
 #   - docker
 
 go:
-  - 1.7
   - 1.8
+  - 1.9
 
 go_import_path: github.com/caicloud/cyclone
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove Go 1.7 and add Go 1.9

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Go 1.7 is not supported after update deps. 
xref: https://travis-ci.org/caicloud/cyclone/jobs/357780015#L480

Fixes #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:

```release-note
Not support Go 1.7 and add the support of Go 1.9.
```
