### PR TITLE
fix:fix bug statistic of pipeline the divisor cannot be 0

### DIFF
--- a/pkg/server/manager/pipeline.go
+++ b/pkg/server/manager/pipeline.go
@@ -470,7 +470,10 @@ func transRecordsToStats(records []api.PipelineRecord, start, end time.Time) (*a
 		statistics.Overview.StatsStatus = statsStatus(statistics.Overview.StatsStatus, record.Status)
 	}
 
-	statistics.Overview.SuccessRatio = fmt.Sprintf("%.2f%%", float64(statistics.Overview.Success)/float64(statistics.Overview.Total)*100)
+	if statistics.Overview.Total != 0 {
+		statistics.Overview.SuccessRatio = fmt.Sprintf("%.2f%%",
+			float64(statistics.Overview.Success)/float64(statistics.Overview.Total)*100)
+	}
 	return statistics, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

statistic of pipeline the divisor cannot be 0

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
