### PR TITLE
fix(gitlab):tag is always created based on master for Gitlab

### DIFF
--- a/pkg/scm/provider/github.go
+++ b/pkg/scm/provider/github.go
@@ -294,18 +294,20 @@ func newClientByBasicAuth(username, password string) (*github.Client, error) {
 }
 
 // newClientByToken news GitHub client by token.
-func newClientByToken(token string) (*github.Client, error) {
+func newClientByToken(token string) *github.Client {
 	// Use token to new GitHub client.
 	tokenSource := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	httpClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
 
-	return github.NewClient(httpClient), nil
+	return github.NewClient(httpClient)
 }
 
 // NewTagFromLatest generate a new tag
-func (g *GitHub) NewTagFromLatest(tagName, description, commitID, url, token string) error {
+func (g *GitHub) NewTagFromLatest(cfg *api.SCMConfig, tagName, description, commitID, url string) error {
+	client := newClientByToken(cfg.Token)
+
 	objecttype := "commit"
 	curtime := time.Now()
 	email := "circle@caicloud.io"
@@ -324,12 +326,6 @@ func (g *GitHub) NewTagFromLatest(tagName, description, commitID, url, token str
 			Email: &email,
 		},
 	}
-
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(oauth2.NoContext, ts)
-	client := github.NewClient(tc)
 
 	owner, repo := parseURL(url)
 	_, _, err := client.Git.CreateTag(owner, repo, tag)

--- a/pkg/scm/provider/gitlab.go
+++ b/pkg/scm/provider/gitlab.go
@@ -273,19 +273,19 @@ func newGitLabClient(server, username, token string) (*gitlab.Client, error) {
 }
 
 // NewTagFromLatest generate a new tag
-func (g *GitLab) NewTagFromLatest(tagName, description, commitID, url, token string) error {
+func (g *GitLab) NewTagFromLatest(cfg *api.SCMConfig, tagName, description, commitID, url string) error {
+	client, err := newGitLabClient(cfg.Server, cfg.Username, cfg.Token)
+	if err != nil {
+		return err
+	}
+
 	owner, name := parseURL(url)
-	ref := "master"
 	tag := &gitlab.CreateTagOptions{
 		TagName: &tagName,
-		Ref:     &ref,
+		Ref:     &commitID,
 		Message: &description,
 	}
 
-	gitlabServer := "https://gitlab.com"
-	client := gitlab.NewOAuthClient(nil, token)
-	client.SetBaseURL(gitlabServer + "/api/v3/")
-
-	_, _, err := client.Tags.CreateTag(owner+"/"+name, tag)
+	_, _, err = client.Tags.CreateTag(owner+"/"+name, tag)
 	return err
 }

--- a/pkg/scm/provider/svn.go
+++ b/pkg/scm/provider/svn.go
@@ -80,8 +80,8 @@ func (s *SVN) CheckToken(scm *api.SCMConfig) bool {
 	return true
 }
 
-func (s *SVN) NewTagFromLatest(tagName, description, commitID, url, token string) error {
-	username, password, err := s.spilitToken(token)
+func (s *SVN) NewTagFromLatest(scm *api.SCMConfig, tagName, description, commitID, url string) error {
+	username, password, err := s.spilitToken(scm.Token)
 	if err != nil {
 		return err
 	}

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -52,7 +52,7 @@ type SCMProvider interface {
 	ListBranches(scm *api.SCMConfig, repo string) ([]string, error)
 	ListTags(scm *api.SCMConfig, repo string) ([]string, error)
 	CheckToken(scm *api.SCMConfig) bool
-	NewTagFromLatest(tagName, description, commitID, url, token string) error
+	NewTagFromLatest(scm *api.SCMConfig, tagName, description, commitID, url string) error
 	CreateWebHook(scm *api.SCMConfig, repoURL string, webHook *WebHook) error
 	DeleteWebHook(scm *api.SCMConfig, repoURL string, webHookUrl string) error
 }
@@ -145,7 +145,7 @@ func GenerateSCMToken(config *api.SCMConfig) error {
 	return nil
 }
 
-func NewTagFromLatest(codeSource *api.CodeSource, tagName, description, token string) error {
+func NewTagFromLatest(codeSource *api.CodeSource, scm *api.SCMConfig, tagName, description string) error {
 	commitID, err := wscm.GetCommitID(codeSource, "")
 	if err != nil {
 		return err
@@ -164,7 +164,7 @@ func NewTagFromLatest(codeSource *api.CodeSource, tagName, description, token st
 		return err
 	}
 
-	err = p.NewTagFromLatest(tagName, description, commitID, url, token)
+	err = p.NewTagFromLatest(scm, tagName, description, commitID, url)
 	if err != nil {
 		return err
 	}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -138,7 +138,7 @@ func (worker *Worker) HandleEvent(event *api.Event) {
 
 	if event.PipelineRecord.PerformParams.CreateSCMTag {
 		codesource := event.Pipeline.Build.Stages.CodeCheckout.MainRepo
-		err = scm.NewTagFromLatest(codesource, event.PipelineRecord.Name, event.PipelineRecord.PerformParams.Description, project.SCM.Token)
+		err = scm.NewTagFromLatest(codesource, project.SCM, event.PipelineRecord.Name, event.PipelineRecord.PerformParams.Description)
 		if err != nil {
 			logdog.Errorf("new tag from latest fail : %v", err)
 			event.PipelineRecord.Status = api.Failed


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

tag is always created based on master for Gitlab

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #425 

**Special notes for your reviewer**:

/cc @supereagle 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
