### PR TITLE
fix(webhook):executing pipeline failed when the trigger is PR webhook

### DIFF
--- a/pkg/server/router/webhook.go
+++ b/pkg/server/router/webhook.go
@@ -113,7 +113,7 @@ func (router *router) handleGithubWebhook(request *restful.Request, response *re
 		}
 
 		performParams = &api.PipelinePerformParams{
-			Ref:         fmt.Sprintf(githubPullRefTemplate, event.PullRequest.Number),
+			Ref:         fmt.Sprintf(githubPullRefTemplate, *event.PullRequest.Number),
 			Description: "Triggered by pull request",
 			Stages:      scmTrigger.PullRequest.Stages,
 		}
@@ -143,7 +143,7 @@ func (router *router) handleGithubWebhook(request *restful.Request, response *re
 
 		if trigger {
 			performParams = &api.PipelinePerformParams{
-				Ref:         fmt.Sprintf(githubPullRefTemplate, event.PullRequest.Number),
+				Ref:         fmt.Sprintf(githubPullRefTemplate, *event.PullRequest.Number),
 				Description: "Triggered by pull request comments",
 				Stages:      scmTrigger.PullRequestComment.Stages,
 			}
@@ -229,10 +229,11 @@ func (router *router) handleGitlabWebhook(request *restful.Request, response *re
 		}
 
 		performParams = &api.PipelinePerformParams{
-			Ref:         fmt.Sprintf(gitlabMergeRefTemplate, objectAttributes.ID),
+			Ref:         fmt.Sprintf(gitlabMergeRefTemplate, objectAttributes.Iid),
 			Description: objectAttributes.Title,
 			Stages:      scmTrigger.PullRequest.Stages,
 		}
+
 		log.Info("Triggered by Gitlab merge event")
 	case *gitlab.MergeCommentEvent:
 		if scmTrigger.PullRequestComment == nil {
@@ -252,7 +253,7 @@ func (router *router) handleGitlabWebhook(request *restful.Request, response *re
 
 		if trigger {
 			performParams = &api.PipelinePerformParams{
-				Ref:         fmt.Sprintf(gitlabMergeRefTemplate, event.MergeRequest.ID),
+				Ref:         fmt.Sprintf(gitlabMergeRefTemplate, event.MergeRequest.IID),
 				Description: "Triggered by pull request comments",
 				Stages:      scmTrigger.PullRequestComment.Stages,
 			}

--- a/pkg/worker/scm/provider/git.go
+++ b/pkg/worker/scm/provider/git.go
@@ -72,7 +72,7 @@ func insert(url, insertion string, index int) string {
 }
 
 func (g *Git) Clone(token, url, ref, destPath string) (string, error) {
-	log.Info("About to clone git repository.", log.Fields{"url": url, "destPath": destPath})
+	log.Info("About to clone git repository.", log.Fields{"url": url, "ref": ref, "destPath": destPath})
 	url, err := g.rebuildURL(token, url)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #459 

**Special notes for your reviewer**:

/cc @supereagle 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
