### PR TITLE
add MIMEText Producer to pipelineRecord Api Descriptor

### DIFF
--- a/pkg/api/v1/descriptor/pipelineRecord.go
+++ b/pkg/api/v1/descriptor/pipelineRecord.go
@@ -109,6 +109,7 @@ var records = []definition.Descriptor{
 		Definitions: []definition.Definition{
 			{
 				Method:      definition.Get,
+				Produces:    []string{definition.MIMEText},
 				Function:    handler.GetPipelineRecordLogs,
 				Description: "Get the pipeline record log",
 				Parameters: []definition.Parameter{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

response the right content-type header in pipelineRecord logs API

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #589

Reference to #589

```release-note
NONE
```