### PR TITLE
fix: use default value of pvc size and resource quota if they are empty

### DIFF
--- a/pkg/server/handler/v1alpha1/helper.go
+++ b/pkg/server/handler/v1alpha1/helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	api "github.com/caicloud/cyclone/pkg/server/apis/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/server/common"
+	"github.com/caicloud/cyclone/pkg/server/config"
 	"github.com/caicloud/cyclone/pkg/server/handler"
 	"github.com/caicloud/cyclone/pkg/util/slugify"
 )
@@ -194,6 +195,25 @@ func GenerateNameModifier(project, tenant string, object interface{}) error {
 		name = slugify.Slugify(name, true, -1)
 	}
 	meta.Name = name
+
+	return nil
+}
+
+// TenantModifier is a modifier of create cyclone tenant.
+// This modifier will give some default value for tenant if it is nil.
+func TenantModifier(project, tenant string, object interface{}) error {
+	t, ok := object.(*api.Tenant)
+	if !ok {
+		return fmt.Errorf("resource type not support")
+	}
+
+	if t.Spec.PersistentVolumeClaim.Size == "" {
+		t.Spec.PersistentVolumeClaim.Size = config.Config.DefaultPVCConfig.Size
+	}
+
+	if t.Spec.ResourceQuota == nil {
+		t.Spec.ResourceQuota = config.Config.WorkerNamespaceQuota
+	}
 
 	return nil
 }

--- a/pkg/server/handler/v1alpha1/tenant.go
+++ b/pkg/server/handler/v1alpha1/tenant.go
@@ -20,7 +20,7 @@ import (
 
 // CreateTenant creates a cyclone tenant
 func CreateTenant(ctx context.Context, tenant *api.Tenant) (*api.Tenant, error) {
-	modifiers := []CreationModifier{GenerateNameModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, TenantModifier}
 	for _, modifier := range modifiers {
 		err := modifier("", "", tenant)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

when create tenant, use default value of pvc size and resource quota if they are empty

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭，caicloud/quality 请用这个。-->

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
