### PR TITLE
add arg -w0 to base64, fix make deploy error

### DIFF
--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -56,7 +56,7 @@ DOCKER_CONFIG=$(cat <<-END
 {
   "auths": {
     "${REGISTRY%/*}": {
-        "auth": "$(echo -n $AUTH | base64 $BASE64_ARGS)"
+        "auth": "$(echo -n $AUTH | base64 ${BASE64_ARGS:-})"
     }
   }
 }
@@ -68,7 +68,7 @@ if [ ! -e ./.generated ]; then
     mkdir ./.generated
 fi
 sed -e "s/__REGISTRY__/${REGISTRY/\//\\/}/g" \
-    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64 $BASE64_ARGS)/g" \
+    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64 ${BASE64_ARGS:-})/g" \
     -e "s/__PVC__/${PVC}/g" \
     -e "s/__VERSION__/${VERSION}/g" \
     ./cyclone.yaml.template > ./.generated/cyclone.yaml

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -48,11 +48,15 @@ if [ -z ${AUTH+x} ]; then echo -e "$RED_COL Please provide auth with --auth=<aut
 if [ -z ${VERSION+x} ]; then echo -e "$RED_COL Please provide version with --version=<version> $NORMAL_COL"; exit 1; fi
 if [ -z ${PVC+x} ]; then echo -e "$RED_COL Please provide PVC with --pvc=<pvc> $NORMAL_COL"; exit 1; fi
 
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    BASE64_ARGS="-w0"
+fi
+
 DOCKER_CONFIG=$(cat <<-END
 {
   "auths": {
     "${REGISTRY%/*}": {
-        "auth": "$(echo -n $AUTH | base64 -w0)"
+        "auth": "$(echo -n $AUTH | base64 $BASE64_ARGS)"
     }
   }
 }
@@ -64,7 +68,7 @@ if [ ! -e ./.generated ]; then
     mkdir ./.generated
 fi
 sed -e "s/__REGISTRY__/${REGISTRY/\//\\/}/g" \
-    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64 -w0)/g" \
+    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64 $BASE64_ARGS)/g" \
     -e "s/__PVC__/${PVC}/g" \
     -e "s/__VERSION__/${VERSION}/g" \
     ./cyclone.yaml.template > ./.generated/cyclone.yaml

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -52,7 +52,7 @@ DOCKER_CONFIG=$(cat <<-END
 {
   "auths": {
     "${REGISTRY%/*}": {
-        "auth": "$(echo -n $AUTH | base64)"
+        "auth": "$(echo -n $AUTH | base64 -w0)"
     }
   }
 }
@@ -64,7 +64,7 @@ if [ ! -e ./.generated ]; then
     mkdir ./.generated
 fi
 sed -e "s/__REGISTRY__/${REGISTRY/\//\\/}/g" \
-    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64)/g" \
+    -e "s/__REGISTRY_AUTH__/$(echo $DOCKER_CONFIG | base64 -w0)/g" \
     -e "s/__PVC__/${PVC}/g" \
     -e "s/__VERSION__/${VERSION}/g" \
     ./cyclone.yaml.template > ./.generated/cyclone.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

make deploy may return error
```
REGISTRIES=xxx AUTH=admin:adminadmin PVC=xxxx make deploy 
./manifests/generate.sh --registry=xxx --auth=admin:adminadmin --version=v0.9.2 --pvc=xxxx
sed: -e expression #2, char 96: unterminated `s' command
make: *** [Makefile:186: deploy] Error 1
```
**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @cd1989 @zhujian7 

```release-note
NONE
```
