### PR TITLE
fix: controller crash as workflowRef nil when create workflowrun

### DIFF
--- a/pkg/workflow/controller/handlers/workflowrun/handler.go
+++ b/pkg/workflow/controller/handlers/workflowrun/handler.go
@@ -29,6 +29,10 @@ func (h *Handler) ObjectCreated(obj interface{}) {
 	}
 	log.WithField("name", originWfr.Name).Debug("Start to process WorkflowRun create")
 
+	if !validate(originWfr) {
+		return
+	}
+
 	// AddOrRefresh adds a WorkflowRun to its corresponding queue, if the queue size exceed the
 	// maximum size, the oldest one would be deleted. And if the WorkflowRun already exists in
 	// the queue, its 'refresh' time field would be refreshed.
@@ -69,6 +73,10 @@ func (h *Handler) ObjectUpdated(obj interface{}) {
 	}
 	log.WithField("name", originWfr.Name).Debug("Start to process WorkflowRun update")
 
+	if !validate(originWfr) {
+		return
+	}
+
 	// Refresh updates 'refresh' time field of the WorkflowRun in the queue.
 	h.LimitedQueues.Refresh(originWfr)
 
@@ -99,4 +107,15 @@ func (h *Handler) ObjectUpdated(obj interface{}) {
 // ObjectDeleted ...
 func (h *Handler) ObjectDeleted(obj interface{}) {
 	return
+}
+
+// validate workflow run
+func validate(wfr *v1alpha1.WorkflowRun) bool {
+	// check workflowRef can not be nil
+	if wfr.Spec.WorkflowRef == nil {
+		log.WithField("name", wfr.Name).Error("WorkflowRef is nil")
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:
Workflow-Controller crashed as workflowRef nil 
```
/Users/zhujian/code/src/github.com/caicloud/cyclone/pkg/workflow/controller/controllers/controller.go:57
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:1333
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf8cd3a]

goroutine 65 [running]:
github.com/caicloud/cyclone/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/zhujian/code/src/github.com/caicloud/cyclone/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x108
panic(0x10c73e0, 0x1da7ef0)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:513 +0x1b9
github.com/caicloud/cyclone/pkg/workflow/workflowrun.key(0xc000177c00, 0xc00000a080, 0x0)
	/Users/zhujian/code/src/github.com/caicloud/cyclone/pkg/workflow/workflowrun/limits.go:42 +0x3a
github.com/caicloud/cyclone/pkg/workflow/workflowrun.(*LimitedQueues).AddOrRefresh(0xc00000b020, 0xc000177c00)
	/Users/zhujian/code/src/github.com/caicloud/cyclone/pkg/workflow/workflowrun/limits.go:60 +0x40
github.com/caicloud/cyclone/pkg/workflow/controller/handlers/workflowrun.(*Handler).ObjectCreated(0xc0001f2ff0, 0x11f0840, 0xc000177c00)
```

Fix this by:
- inject workflowRef while creating wfr by cyclone-server
- validate workflowrun before processing it

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭，caicloud/quality 请用这个。-->

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
