### PR TITLE
feat(server): add api to list all pods for one tenant

### DIFF
--- a/pkg/server/apis/v1alpha1/descriptors/workload.go
+++ b/pkg/server/apis/v1alpha1/descriptors/workload.go
@@ -1,0 +1,38 @@
+package descriptors
+
+import (
+	"github.com/caicloud/nirvana/definition"
+
+	handler "github.com/caicloud/cyclone/pkg/server/handler/v1alpha1"
+	httputil "github.com/caicloud/cyclone/pkg/util/http"
+)
+
+func init() {
+	register(workload...)
+}
+
+var workload = []definition.Descriptor{
+	{
+		Path:        "/runningpods",
+		Description: "Workload APIs",
+		Definitions: []definition.Definition{
+			{
+				Method:      definition.Get,
+				Function:    handler.ListRunningPods,
+				Description: "List running pods",
+				Parameters: []definition.Parameter{
+					{
+						Source: definition.Header,
+						Name:   httputil.TenantHeaderName,
+					},
+					{
+						Source:      definition.Auto,
+						Name:        httputil.PaginationAutoParameter,
+						Description: "pagination",
+					},
+				},
+				Results: definition.DataErrorResults("tenant"),
+			},
+		},
+	},
+}

--- a/pkg/server/apis/v1alpha1/descriptors/workload.go
+++ b/pkg/server/apis/v1alpha1/descriptors/workload.go
@@ -13,13 +13,13 @@ func init() {
 
 var workload = []definition.Descriptor{
 	{
-		Path:        "/runningpods",
+		Path:        "/workingpods",
 		Description: "Workload APIs",
 		Definitions: []definition.Definition{
 			{
 				Method:      definition.Get,
-				Function:    handler.ListRunningPods,
-				Description: "List running pods",
+				Function:    handler.ListWorkingPods,
+				Description: "List all pods of workflowruns",
 				Parameters: []definition.Parameter{
 					{
 						Source: definition.Header,

--- a/pkg/server/common/const.go
+++ b/pkg/server/common/const.go
@@ -77,4 +77,9 @@ const (
 
 	// ControlClusterName is the name of control cluster
 	ControlClusterName = "control-cluster"
+
+	// PodLabelSelector is selector used to select pod created by Cyclone stages
+	// TODO(robin) Copy from pkg/workflow/common/const.go, need to create package pkg/common
+	// to merge pkg/workflow/common and pkg/server/common.
+	PodLabelSelector = "cyclone.io/workflow==true"
 )

--- a/pkg/server/handler/v1alpha1/workload.go
+++ b/pkg/server/handler/v1alpha1/workload.go
@@ -12,9 +12,11 @@ import (
 	"github.com/caicloud/cyclone/pkg/server/types"
 )
 
-// ListRunningPods lists running pods of workflowruns for one tenant.
-func ListRunningPods(ctx context.Context, tenant string, pagination *types.Pagination) (*types.ListResponse, error) {
-	pods, err := handler.K8sClient.CoreV1().Pods(common.TenantNamespace(tenant)).List(metav1.ListOptions{})
+// ListWorkingPods lists all pods of workflowruns.
+func ListWorkingPods(ctx context.Context, tenant string, pagination *types.Pagination) (*types.ListResponse, error) {
+	pods, err := handler.K8sClient.CoreV1().Pods(common.TenantNamespace(tenant)).List(metav1.ListOptions{
+		LabelSelector: common.PodLabelSelector,
+	})
 	if err != nil {
 		log.Errorf("Failed to list pods for tenant %s as error: %v", tenant, err)
 		return nil, err

--- a/pkg/server/handler/v1alpha1/workload.go
+++ b/pkg/server/handler/v1alpha1/workload.go
@@ -1,0 +1,35 @@
+package v1alpha1
+
+import (
+	"context"
+
+	"github.com/caicloud/nirvana/log"
+	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/caicloud/cyclone/pkg/server/common"
+	"github.com/caicloud/cyclone/pkg/server/handler"
+	"github.com/caicloud/cyclone/pkg/server/types"
+)
+
+// ListRunningPods lists running pods of workflowruns for one tenant.
+func ListRunningPods(ctx context.Context, tenant string, pagination *types.Pagination) (*types.ListResponse, error) {
+	pods, err := handler.K8sClient.CoreV1().Pods(common.TenantNamespace(tenant)).List(metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("Failed to list pods for tenant %s as error: %v", tenant, err)
+		return nil, err
+	}
+
+	items := pods.Items
+	size := int64(len(items))
+	if pagination.Start >= size {
+		return types.NewListResponse(int(size), []core_v1.Pod{}), nil
+	}
+
+	end := pagination.Start + pagination.Limit
+	if end > size {
+		end = size
+	}
+
+	return types.NewListResponse(int(size), items[pagination.Start:end]), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add api to list all working pods for one tenant to let users knows about the workload of their workflows.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
