### PR TITLE
Pvc usage collect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ROOT := github.com/caicloud/cyclone
 
 # Target binaries. You can build multiple binaries for a single project.
 TARGETS := server workflow/controller workflow/coordinator
-IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv
+IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv web
 
 # Container image prefix and suffix added to targets.
 # The final built images are:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ROOT := github.com/caicloud/cyclone
 
 # Target binaries. You can build multiple binaries for a single project.
 TARGETS := server workflow/controller workflow/coordinator
-IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv web
+IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv
 
 # Container image prefix and suffix added to targets.
 # The final built images are:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ROOT := github.com/caicloud/cyclone
 
 # Target binaries. You can build multiple binaries for a single project.
 TARGETS := server workflow/controller workflow/coordinator
-IMAGES := server watcher workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv web
+IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv watcher web
 
 # Container image prefix and suffix added to targets.
 # The final built images are:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ROOT := github.com/caicloud/cyclone
 
 # Target binaries. You can build multiple binaries for a single project.
 TARGETS := server workflow/controller workflow/coordinator
-IMAGES := server workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv web
+IMAGES := server watcher workflow/controller workflow/coordinator resolver/git resolver/image resolver/kv web
 
 # Container image prefix and suffix added to targets.
 # The final built images are:

--- a/build/watcher/Dockerfile
+++ b/build/watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM bash:4.1.17
 
 LABEL maintainer="chende@caicloud.io"
 

--- a/build/watcher/Dockerfile
+++ b/build/watcher/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.8
+
+LABEL maintainer="chende@caicloud.io"
+
+WORKDIR /workspace
+
+COPY ./build/watcher/pvc-watcher.sh /workspace/pvc-watcher.sh
+
+CMD ["/workspace/pvc-watcher.sh"]

--- a/build/watcher/pvc-watcher.sh
+++ b/build/watcher/pvc-watcher.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+template=$(cat <<-END
+{
+  "total": "%s",
+  "used": "%s",
+  "items": {%s}
+}
+END
+)
+
+function join_by {
+  local d=$1;
+  shift;
+  echo -n "$1";
+  shift;
+  printf "%s" "${@/#/$d}";
+}
+
+function usage {
+  cd $1
+  total=$(df -h "$1" | grep "$1" | awk '{ print $(NF-4) }')
+  used=$(df -h "$1" | grep "$1" | awk '{ print $(NF-3) }')
+
+  if [ -z "$(ls -A .)" ]; then
+    printf "$template" "$total" "$used" ""
+  else
+    items=$(du -sh -- * | awk '{ printf("\"%s\":\"%s\"\n", $2, $1) }')
+    jsonItems=$(join_by , ${items[@]})
+    printf "$template" "$total" "$used"  "$jsonItems"
+  fi
+}
+
+echo "Report to $REPORT_URL every $HEARTBEAT_INTERVAL seconds."
+while [ true ];
+do
+  json=$(usage "/pvc-data")
+  wget -q --header="Content-Type:application/json" --header="X-Namespace:$NAMESPACE" --post-data="$json" $REPORT_URL;
+  sleep $HEARTBEAT_INTERVAL;
+done

--- a/build/watcher/pvc-watcher.sh
+++ b/build/watcher/pvc-watcher.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/local/bin/bash
 
 template=$(cat <<-END
 {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,7 +34,7 @@ import (
 	_ "github.com/caicloud/cyclone/pkg/server/biz/scm/github"
 	_ "github.com/caicloud/cyclone/pkg/server/biz/scm/gitlab"
 	_ "github.com/caicloud/cyclone/pkg/server/biz/scm/svn"
-	"github.com/caicloud/cyclone/pkg/server/biz/tenants"
+	"github.com/caicloud/cyclone/pkg/server/biz/templates"
 	"github.com/caicloud/cyclone/pkg/server/config"
 	"github.com/caicloud/cyclone/pkg/server/handler"
 	"github.com/caicloud/cyclone/pkg/server/handler/v1alpha1"
@@ -93,7 +93,7 @@ func initialize(opts *Options) {
 	if err != nil {
 		log.Fatalf("Create default tenant cyclone error %v", err)
 	}
-	tenants.InitStageTemplates(client, "")
+	templates.InitStageTemplates(client, "")
 }
 
 func main() {

--- a/manifests/cyclone.yaml.template
+++ b/manifests/cyclone.yaml.template
@@ -79,9 +79,15 @@ data:
         "requests.memory": "2Gi"
       },
       "storage_usage_watcher": {
-        "image": "busybox:1.30.0",
+        "image": "__REGISTRY__/cyclone-watcher:__VERSION__",
         "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storages",
-        "interval_seconds": "30"
+        "interval_seconds": "30",
+        "resource_requirements": {
+          "limits.cpu": "100m",
+          "limits.memory": "64Mi",
+          "requests.cpu": "50m",
+          "requests.memory": "32Mi"
+        }
       }
     }
 

--- a/manifests/cyclone.yaml.template
+++ b/manifests/cyclone.yaml.template
@@ -77,6 +77,11 @@ data:
         "limits.memory": "4Gi",
         "requests.cpu": "1",
         "requests.memory": "2Gi"
+      },
+      "storage_usage_watcher": {
+        "image": "busybox:1.30.0",
+        "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storages",
+        "interval_seconds": "30"
       }
     }
 

--- a/manifests/cyclone.yaml.template
+++ b/manifests/cyclone.yaml.template
@@ -80,7 +80,7 @@ data:
       },
       "storage_usage_watcher": {
         "image": "__REGISTRY__/cyclone-watcher:__VERSION__",
-        "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storages",
+        "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storage/usages",
         "interval_seconds": "30",
         "resource_requirements": {
           "limits.cpu": "100m",

--- a/pkg/server/apis/v1alpha1/descriptors/usage.go
+++ b/pkg/server/apis/v1alpha1/descriptors/usage.go
@@ -1,0 +1,38 @@
+package descriptors
+
+import (
+	"github.com/caicloud/nirvana/definition"
+
+	handler "github.com/caicloud/cyclone/pkg/server/handler/v1alpha1"
+	httputil "github.com/caicloud/cyclone/pkg/util/http"
+)
+
+func init() {
+	register(usages...)
+}
+
+var usages = []definition.Descriptor{
+	{
+		Path:        "/storage/usages",
+		Description: "Storage usages APIs",
+		Definitions: []definition.Definition{
+			{
+				Method:      definition.Create,
+				Function:    handler.ReportStorageUsage,
+				Description: "Report storage usages",
+				Parameters: []definition.Parameter{
+					{
+						Source:      definition.Header,
+						Name:        httputil.NamespaceHeaderName,
+						Description: "Namespace",
+					},
+					{
+						Source:      definition.Body,
+						Description: "JSON body to describe the usages",
+					},
+				},
+				Results: []definition.Result{definition.ErrorResult()},
+			},
+		},
+	},
+}

--- a/pkg/server/apis/v1alpha1/types.go
+++ b/pkg/server/apis/v1alpha1/types.go
@@ -263,5 +263,7 @@ type WebhookResponse struct {
 
 // StorageUsage defines usage of PVC storage
 type StorageUsage struct {
-	Data string `json:"data"`
+	Total string            `json:"total"`
+	Used  string            `json:"used"`
+	Items map[string]string `json:"items"`
 }

--- a/pkg/server/apis/v1alpha1/types.go
+++ b/pkg/server/apis/v1alpha1/types.go
@@ -260,3 +260,8 @@ type HealthStatus struct {
 type WebhookResponse struct {
 	Message string `json:"message,omitempty"`
 }
+
+// StorageUsage defines usage of PVC storage
+type StorageUsage struct {
+	Data string `json:"data"`
+}

--- a/pkg/server/biz/statistic/usage.go
+++ b/pkg/server/biz/statistic/usage.go
@@ -1,0 +1,76 @@
+package statistic
+
+import (
+	"fmt"
+
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	"github.com/caicloud/cyclone/pkg/k8s/clientset"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Usage represents usage of some resources, for example storage
+type Usage struct {
+	Total int64 `json:"total"`
+	Used  int64 `json:"used"`
+}
+
+// PVCUsage represents PVC usages in a tenant
+type PVCUsage struct {
+	// Overall is overall usage of the PVC storage
+	Overall Usage `json:"overall"`
+	// Projects are storage used by each project
+	Projects map[string]int64 `json:"projects"`
+}
+
+// PVCWatcherName is name of the PVC watcher deployment and pod
+const PVCWatcherName = "pvc-watchdog"
+
+// LaunchPVCUsageWatcher launches a pod in a given namespace to report PVC usage regularly.
+func LaunchPVCUsageWatcher(client clientset.Interface, context v1alpha1.ExecutionContext) error {
+	if len(context.PVC) == 0 {
+		return fmt.Errorf("no pvc in execution namespace %s", context.Namespace)
+	}
+
+	_, err := client.ExtensionsV1beta1().Deployments(context.Namespace).Create(&v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PVCWatcherName,
+			Namespace: context.Namespace,
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PVCWatcherName,
+					Namespace: context.Namespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "c0",
+							Image: "insight.caicloudprivatetest.com/release/busybox:1.30.0",
+							Command: []string{
+								"/bin/sh",
+								"-c",
+								"",
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "cv",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: context.PVC,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			},
+		},
+	})
+	return err
+}

--- a/pkg/server/biz/statistic/usage.go
+++ b/pkg/server/biz/statistic/usage.go
@@ -4,10 +4,21 @@ import (
 	"fmt"
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
-	"github.com/caicloud/cyclone/pkg/k8s/clientset"
+	"github.com/caicloud/cyclone/pkg/server/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// ReportURLEnvName ...
+	ReportURLEnvName = "REPORT_URL"
+	// HeartbeatIntervalEnvName ...
+	HeartbeatIntervalEnvName = "HEARTBEAT_INTERVAL"
+	// NamespaceEnvName ...
+	NamespaceEnvName = "NAMESPACE"
 )
 
 // Usage represents usage of some resources, for example storage
@@ -28,11 +39,12 @@ type PVCUsage struct {
 const PVCWatcherName = "pvc-watchdog"
 
 // LaunchPVCUsageWatcher launches a pod in a given namespace to report PVC usage regularly.
-func LaunchPVCUsageWatcher(client clientset.Interface, context v1alpha1.ExecutionContext) error {
+func LaunchPVCUsageWatcher(client *kubernetes.Clientset, context v1alpha1.ExecutionContext) error {
 	if len(context.PVC) == 0 {
 		return fmt.Errorf("no pvc in execution namespace %s", context.Namespace)
 	}
 
+	watcherConfig := config.Config.StorageUsageWatcher
 	_, err := client.ExtensionsV1beta1().Deployments(context.Namespace).Create(&v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PVCWatcherName,
@@ -48,11 +60,43 @@ func LaunchPVCUsageWatcher(client clientset.Interface, context v1alpha1.Executio
 					Containers: []corev1.Container{
 						{
 							Name:  "c0",
-							Image: "insight.caicloudprivatetest.com/release/busybox:1.30.0",
+							Image: watcherConfig.Image,
+							Env: []corev1.EnvVar{
+								{
+									Name:  ReportURLEnvName,
+									Value: watcherConfig.ReportURL,
+								},
+								{
+									Name:  HeartbeatIntervalEnvName,
+									Value: watcherConfig.IntervalSeconds,
+								},
+								{
+									Name:  NamespaceEnvName,
+									Value: context.Namespace,
+								},
+							},
 							Command: []string{
 								"/bin/sh",
 								"-c",
-								"",
+								`while [ true ]; do wget -q --header="Content-Type:application/json" --header="X-Namespace:$NAMESPACE" --post-data="{data: $(stat -tf /data | grep "/data" | awk '{ print $5":"$6":"$7 }')}" $REPORT_URL; sleep $HEARTBEAT_INTERVAL; done`,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "cv",
+									ReadOnly:  true,
+									MountPath: "/data",
+									SubPath:   "caches",
+								},
 							},
 						},
 					},
@@ -72,5 +116,6 @@ func LaunchPVCUsageWatcher(client clientset.Interface, context v1alpha1.Executio
 			},
 		},
 	})
+
 	return err
 }

--- a/pkg/server/biz/templates/templates.go
+++ b/pkg/server/biz/templates/templates.go
@@ -1,4 +1,4 @@
-package tenants
+package templates
 
 import (
 	"os"
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
-	"github.com/caicloud/cyclone/pkg/server/biz/templates"
 	"github.com/caicloud/cyclone/pkg/server/common"
 )
 
@@ -19,7 +18,7 @@ func InitStageTemplates(client clientset.Interface, scene string) {
 
 	// Load all stage templates. Template files path is given by environment variable
 	// TEMPLATES_PATH, if not set, use default one "/root/templates"
-	loader := &templates.StageTemplatesLoader{TemplatesDir: os.Getenv(templates.TemplatesPathEnvName)}
+	loader := &StageTemplatesLoader{TemplatesDir: os.Getenv(TemplatesPathEnvName)}
 	stages, err := loader.LoadStageTemplates(scene)
 	if err != nil {
 		log.Errorf("Load stage templates error: %v", err)

--- a/pkg/server/common/const.go
+++ b/pkg/server/common/const.go
@@ -66,6 +66,9 @@ const (
 	// AnnotationDescription is the annotation key used to describe resources
 	AnnotationDescription = "cyclone.io/description"
 
+	// AnnotationStorageUsage is annotation to store storage usuage information
+	AnnotationStorageUsage = "storage.cyclone.io/usage"
+
 	// QuotaCPULimit represents default value of 'limits.cpu'
 	QuotaCPULimit = "2"
 	// QuotaCPURequest represents default value of 'requests.cpu'

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -35,6 +35,9 @@ type CycloneServerConfig struct {
 	// WebhookURL represents the Cyclone server path to receive webhook requests.
 	// If Cyclone server can be accessed by external systems, it would like be `https://{cyclone-server}/apis/v1alpha1`.
 	WebhookURL string `json:"webhook_url"`
+
+	// StorageUsageWatcher configures PVC storage usage watchers.
+	StorageUsageWatcher StorageUsageWatcher `json:"storage_usage_watcher"`
 }
 
 // PVCConfig contains the PVC information
@@ -50,6 +53,16 @@ type PVCConfig struct {
 // LoggingConfig configures logging
 type LoggingConfig struct {
 	Level string `json:"level"`
+}
+
+// StorageUsageWatcher configures PVC storage usage watchers.
+type StorageUsageWatcher struct {
+	// Image is image for the storage usage watcher, for example 'busybox:1.30.0'
+	Image string `json:"image"`
+	// ReportURL is url where to report the usage
+	ReportURL string `json:"report_url"`
+	// IntervalSeconds is intervals to report storage usage
+	IntervalSeconds string `json:"interval_seconds"`
 }
 
 // Config is Workflow Controller config instance

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -63,6 +63,8 @@ type StorageUsageWatcher struct {
 	ReportURL string `json:"report_url"`
 	// IntervalSeconds is intervals to report storage usage
 	IntervalSeconds string `json:"interval_seconds"`
+	// ResourceRequirements specifies resource requirements of the watcher container.
+	ResourceRequirements map[core_v1.ResourceName]string `json:"resource_requirements"`
 }
 
 // Config is Workflow Controller config instance

--- a/pkg/server/handler/v1alpha1/integration.go
+++ b/pkg/server/handler/v1alpha1/integration.go
@@ -10,8 +10,10 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	api "github.com/caicloud/cyclone/pkg/server/apis/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/server/biz/scm"
+	"github.com/caicloud/cyclone/pkg/server/biz/statistic"
 	"github.com/caicloud/cyclone/pkg/server/common"
 	"github.com/caicloud/cyclone/pkg/server/config"
 	"github.com/caicloud/cyclone/pkg/server/handler"
@@ -186,6 +188,15 @@ func OpenClusterForTenant(cluster *api.ClusterSource, tenantName string) (err er
 		}
 
 		cluster.PVC = common.TenantPVC(tenant.Name)
+	}
+
+	// Launch PVC usage watcher to watch the usage of PVC.
+	err = statistic.LaunchPVCUsageWatcher(client, v1alpha1.ExecutionContext{
+		Namespace: cluster.Namespace,
+		PVC:       cluster.PVC,
+	})
+	if err != nil {
+		log.Warningf("Launch PVC usage watcher for %s/%s error: %v", cluster.Namespace, cluster.PVC, err)
 	}
 
 	return nil

--- a/pkg/server/handler/v1alpha1/integration.go
+++ b/pkg/server/handler/v1alpha1/integration.go
@@ -241,6 +241,12 @@ func CloseClusterForTenant(cluster *api.ClusterSource, tenant string) (err error
 		return
 	}
 
+	// Delete the PVC wathcer deployment.
+	err = client.ExtensionsV1beta1().Deployments(cluster.Namespace).Delete(statistic.PVCWatcherName, &meta_v1.DeleteOptions{})
+	if err != nil {
+		log.Warningf("Delete PVC watcher '%s' error: %v", statistic.PVCWatcherName, err)
+	}
+
 	// delete pvc which is created by cyclone
 	if cluster.PVC == common.TenantPVC(tenant) {
 		err = client.CoreV1().PersistentVolumeClaims(cluster.Namespace).Delete(cluster.PVC, &meta_v1.DeleteOptions{})

--- a/pkg/server/handler/v1alpha1/usage.go
+++ b/pkg/server/handler/v1alpha1/usage.go
@@ -1,0 +1,74 @@
+package v1alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/caicloud/cyclone/pkg/server/apis/v1alpha1"
+	"github.com/caicloud/cyclone/pkg/server/biz/statistic"
+	"github.com/caicloud/cyclone/pkg/server/common"
+	"github.com/caicloud/cyclone/pkg/server/handler"
+	"github.com/caicloud/nirvana/log"
+)
+
+// ReportStorageUsage reports storage usage of a namespace.
+func ReportStorageUsage(ctx context.Context, namespace string, request v1alpha1.StorageUsage) error {
+	log.Infof("update storage usuage, namespace: %s, usage: %s", namespace, request.Data)
+	usage, err := parseUsageData(request.Data)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(usage)
+	if err != nil {
+		return fmt.Errorf("marshal usage error: %v", err)
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ns, err := handler.K8sClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+
+		ns.Annotations[common.AnnotationStorageUsage] = string(b)
+
+		_, err = handler.K8sClient.CoreV1().Namespaces().Update(ns)
+		return err
+	})
+}
+
+// parseUsageData parses the raw usage data, the data is in format: <block-size-in-byte>:<total-blocks>:<free-blocks>
+func parseUsageData(data string) (*statistic.Usage, error) {
+	parts := strings.Split(data, ":")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid usage string: %s", data)
+	}
+
+	blockSize, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid usage string: %s", data)
+	}
+	total, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid usage string: %s", data)
+	}
+	free, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid usage string: %s", data)
+	}
+
+	return &statistic.Usage{
+		Total: total * blockSize,
+		Used:  (total - free) * blockSize,
+	}, nil
+}

--- a/pkg/util/http/http.go
+++ b/pkg/util/http/http.go
@@ -70,6 +70,9 @@ const (
 	// TenantHeaderName is name of tenant header name in http reqeust
 	TenantHeaderName = "X-Tenant"
 
+	// NamespaceHeaderName is name of namespace header
+	NamespaceHeaderName = "X-Namespace"
+
 	// HeaderContentType represents the the key of Content-Type.
 	HeaderContentType = "Content-Type"
 

--- a/release/cyclone-server.yaml
+++ b/release/cyclone-server.yaml
@@ -61,6 +61,17 @@ _config:
               "limits.memory": "4Gi",
               "requests.cpu": "1",
               "requests.memory": "2Gi"
+            },
+            "storage_usage_watcher": {
+              "image": "__REGISTRY__/cyclone-watcher:__VERSION__",
+              "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storage/usages",
+              "interval_seconds": "30",
+              "resource_requirements": {
+                "limits.cpu": "100m",
+                "limits.memory": "64Mi",
+                "requests.cpu": "50m",
+                "requests.memory": "32Mi"
+              }
             }
           }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Deploy a PVC usage watcher pod for each execution namespace to collect PVC usage information.

PVC usage info would be set in namespace annotation:

```
storage.cyclone.io/usage: '{"total":"10.0G","used":"0","items":{"caches":"4.5K","workflowruns":"4.5K"}}'
```
**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
