### PR TITLE
feat: whether a stage in workflow is trivial

### DIFF
--- a/pkg/apis/cyclone/v1alpha1/workflow.go
+++ b/pkg/apis/cyclone/v1alpha1/workflow.go
@@ -74,8 +74,12 @@ type StageItem struct {
 	Name string `json:"name"`
 	// Input artifacts that this stage needed, we bind the artifacts source here.
 	Artifacts []ArtifactItem `json:"artifacts"`
-	// Stages that this stage depends on
+	// Stages that this stage depends on.
 	Depends []string `json:"depends"`
+	// Trivial indicates whether this stage is critical in the workflow. If set to true, it means the workflow
+	// can tolerate failure of this stage. In this case, all other stages can continue to execute and the overall
+	// status of the workflow execution can still be succeed.
+	Trivial bool `json:"trivial"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/workflow/workflowrun/utils.go
+++ b/pkg/workflow/workflowrun/utils.go
@@ -49,7 +49,7 @@ func NextStages(wf *v1alpha1.Workflow, wfr *v1alpha1.WorkflowRun) []string {
 		safeToRun := true
 		for _, d := range stage.Depends {
 			status, ok := wfr.Status.Stages[d]
-			if !(ok && status.Status.Phase == v1alpha1.StatusSucceeded) {
+			if !(ok && (status.Status.Phase == v1alpha1.StatusSucceeded || (status.Status.Phase == v1alpha1.StatusFailed && IsTrivial(wf, d)))) {
 				safeToRun = false
 				break
 			}
@@ -61,6 +61,17 @@ func NextStages(wf *v1alpha1.Workflow, wfr *v1alpha1.WorkflowRun) []string {
 	}
 
 	return nextStages
+}
+
+// IsTrivial returns whether a stage is trivial in a workflow
+func IsTrivial(wf *v1alpha1.Workflow, stage string) bool {
+	for _, s := range wf.Spec.Stages {
+		if s.Name == stage {
+			return s.Trivial
+		}
+	}
+
+	return false
 }
 
 // staticStatus masks timestamp in status, safe for comparision of status.

--- a/pkg/workflow/workflowrun/utils_test.go
+++ b/pkg/workflow/workflowrun/utils_test.go
@@ -65,6 +65,31 @@ func TestResolveStatus(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestIsTrivial(t *testing.T) {
+	wf := &v1alpha1.Workflow{
+		Spec: v1alpha1.WorkflowSpec{
+			Stages: []v1alpha1.StageItem{
+				{
+					Name:    "A",
+					Trivial: false,
+				},
+				{
+					Name:    "B",
+					Trivial: false,
+					Depends: []string{"A"},
+				},
+				{
+					Name:    "C",
+					Trivial: true,
+				},
+			},
+		},
+	}
+	assert.Equal(t, false, IsTrivial(wf, "A"))
+	assert.Equal(t, false, IsTrivial(wf, "B"))
+	assert.Equal(t, true, IsTrivial(wf, "C"))
+}
+
 func TestNextStages(t *testing.T) {
 	wf := &v1alpha1.Workflow{
 		Spec: v1alpha1.WorkflowSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add field 'trivial' to stages in Workflow, to indicate whether workflow can tolerate failure of the stage.
If a stage is trivial to a workflow, failure of the stage won't affect the overall stage of the workflow.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
