### PR TITLE
chore: list system builtin templates with builtin label

### DIFF
--- a/pkg/meta/labels.go
+++ b/pkg/meta/labels.go
@@ -106,6 +106,11 @@ func StageTemplateSelector() string {
 	return fmt.Sprintf("%s=%s", LabelStageTemplate, TrueValue)
 }
 
+// BuiltinLabelSelector returns a label selector to query cyclone built-in resources.
+func BuiltinLabelSelector() string {
+	return fmt.Sprintf("%s=%s", LabelBuiltin, TrueValue)
+}
+
 // LabelExistsSelector returns a label selector to query resources with label key exists.
 func LabelExistsSelector(key string) string {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{

--- a/pkg/server/handler/v1alpha1/template.go
+++ b/pkg/server/handler/v1alpha1/template.go
@@ -34,7 +34,7 @@ func ListTemplates(ctx context.Context, tenant string, includePublic bool, query
 	items := templates.Items
 	if tenant != common.AdminTenant && includePublic {
 		publicTemplates, err := handler.K8sClient.CycloneV1alpha1().Stages(common.TenantNamespace(common.AdminTenant)).List(metav1.ListOptions{
-			LabelSelector: meta.StageTemplateSelector(),
+			LabelSelector: meta.StageTemplateSelector() + "," + meta.BuiltinLabelSelector(),
 		})
 		if err != nil {
 			log.Errorf("Get templates from k8s with tenant %s error: %v", common.AdminTenant, err)

--- a/pkg/server/handler/v1alpha1/workflowrun.go
+++ b/pkg/server/handler/v1alpha1/workflowrun.go
@@ -194,7 +194,7 @@ func ReceiveContainerLogStream(ctx context.Context, workflowrun, namespace, stag
 	// get workflowrun
 	wfr, err := handler.K8sClient.CycloneV1alpha1().WorkflowRuns(namespace).Get(workflowrun, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("get wfr %s error %s", wfr, err)
+		log.Errorf("get wfr %s/%s error %s", namespace, workflowrun, err)
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

we wish system admin tenant have two types of templates:
- templates shared among tenants with built-in label
- templates cannot be shared(private) without built-in label

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
