### PR TITLE
fix: rename template query type to keep consistent with label

### DIFF
--- a/pkg/server/handler/v1alpha1/template.go
+++ b/pkg/server/handler/v1alpha1/template.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/caicloud/nirvana/log"
@@ -19,8 +20,8 @@ import (
 )
 
 const (
-	// TemplateTypeBuildin represents the type of buildin templates.
-	TemplateTypeBuildin = "buildin"
+	// TemplateTypeBuiltin represents the type of builtin templates.
+	TemplateTypeBuiltin = "builtin"
 
 	// TemplateTypeCustom represents the type of custom templates.
 	TemplateTypeCustom = "custom"
@@ -88,6 +89,12 @@ func filterTemplates(stages []v1alpha1.Stage, filter string) ([]v1alpha1.Stage, 
 			return nil, cerr.ErrorQueryParamNotCorrect.Error(filter)
 		}
 
+		if kv[0] == "type" {
+			if kv[1] != TemplateTypeBuiltin && kv[1] != TemplateTypeCustom {
+				return nil, cerr.ErrorValidationFailed.Error(filter, fmt.Errorf("template types only support: %s, %s", TemplateTypeBuiltin, TemplateTypeCustom))
+			}
+		}
+
 		filters[kv[0]] = strings.ToLower(kv[1])
 	}
 
@@ -113,10 +120,10 @@ func filterTemplates(stages []v1alpha1.Stage, filter string) ([]v1alpha1.Stage, 
 			case "type":
 				if item.Labels != nil {
 					// Templates will be skipped when meet one of the conditions:
-					// * there is buildin label, and the query type is custom
-					// * there is no buildin label, but the query type is buildin
+					// * there is builtin label, and the query type is custom
+					// * there is no builtin label, but the query type is builtin
 					_, ok := item.Labels[meta.LabelBuiltin]
-					if (ok && value == TemplateTypeCustom) || (!ok && value == TemplateTypeBuildin) {
+					if (ok && (value == TemplateTypeCustom)) || (!ok && (value == TemplateTypeBuiltin)) {
 						selected = false
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

* Rename `buildin` to `builtin` for template type query
* Add param validation for  template type query

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
