### PR TITLE
fix: gc pod memory quota limit

### DIFF
--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -93,10 +93,10 @@ wrapPull() {
 
 # Revision can be in two different format:
 # - Single revision. For example, 'master', 'develop' as branch, 'v1.0' as tag, etc.
-# - Composite revision. For example, 'develop->master', it means merge branch 'develop' to 'master'. It's used in merge
+# - Composite revision. For example, 'develop:master', it means merge branch 'develop' to 'master'. It's used in merge
 #   request in GitLab.
 # This function parses the composite revision to get the source and target branches. For example,
-#   'develop->master' --> ['develop', 'master']
+#   'develop:master' --> ['develop', 'master']
 parseRevision() {
     SOURCE_BRANCH=${GIT_REVISION%%:*}
     TARGET_BRANCH=${GIT_REVISION##*:}

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -449,7 +449,7 @@ func (o *operator) GC(lastTry, wfrDeletion bool) error {
 							},
 							Limits: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("648Mi"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Some comments in resolver entrypoint.sh is outdated.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
