### PR TITLE
fix: delete logs in pvc while deleting associated cyclone resources

### DIFF
--- a/pkg/server/handler/v1alpha1/helper.go
+++ b/pkg/server/handler/v1alpha1/helper.go
@@ -43,6 +43,36 @@ func getLogFolder(tenant, project, workflow, workflowrun string) (string, error)
 	return strings.Join([]string{cycloneHome, tenant, project, workflow, workflowrun, logsFolderName}, string(os.PathSeparator)), nil
 }
 
+// deleteCollections deletes collections in the sub paths of a tenant in the pvc, collections including:
+// - logs
+// - artifacts (WIP)
+// subpaths could be:
+// - project
+// - workflow
+// - workflowrun
+func deleteCollections(tenant string, subpaths ...string) error {
+	if tenant == "" {
+		return fmt.Errorf("tenant can not be empty")
+	}
+
+	// get collection folder
+	folder := getCollectionFolder(tenant, subpaths...)
+
+	// remove collection folder
+	if err := os.RemoveAll(folder); err != nil {
+		log.Errorf("remove folder %s error:%v", folder, err)
+		return err
+	}
+
+	return nil
+}
+
+func getCollectionFolder(tenant string, subpaths ...string) string {
+	paths := []string{cycloneHome, tenant}
+	paths = append(paths, subpaths...)
+	return strings.Join(paths, string(os.PathSeparator))
+}
+
 // GetMetadata gets metadata of a type of k8s resources
 type GetMetadata func(string, string) (meta_v1.ObjectMeta, error)
 

--- a/pkg/server/handler/v1alpha1/project.go
+++ b/pkg/server/handler/v1alpha1/project.go
@@ -91,8 +91,12 @@ func UpdateProject(ctx context.Context, tenant, pName string, project *v1alpha1.
 
 // DeleteProject deletes a project with the given tenant and project name.
 func DeleteProject(ctx context.Context, tenant, project string) error {
-	err := handler.K8sClient.CycloneV1alpha1().Projects(common.TenantNamespace(tenant)).Delete(project, &metav1.DeleteOptions{})
+	err := deleteCollections(tenant, project)
+	if err != nil {
+		return err
+	}
 
+	err = handler.K8sClient.CycloneV1alpha1().Projects(common.TenantNamespace(tenant)).Delete(project, &metav1.DeleteOptions{})
 	return cerr.ConvertK8sError(err)
 }
 

--- a/pkg/server/handler/v1alpha1/tenant.go
+++ b/pkg/server/handler/v1alpha1/tenant.go
@@ -203,6 +203,11 @@ func DeleteTenant(ctx context.Context, name string) error {
 		}
 	}
 
+	err = deleteCollections(name)
+	if err != nil {
+		return err
+	}
+
 	err = handler.K8sClient.CoreV1().Namespaces().Delete(common.TenantNamespace(name), &meta_v1.DeleteOptions{})
 	if err != nil {
 		log.Errorf("Delete namespace for tenant %s error %v", name, err)

--- a/pkg/server/handler/v1alpha1/workflow.go
+++ b/pkg/server/handler/v1alpha1/workflow.go
@@ -120,8 +120,12 @@ func UpdateWorkflow(ctx context.Context, tenant, project, workflow string, wf *v
 
 // DeleteWorkflow ...
 func DeleteWorkflow(ctx context.Context, tenant, project, workflow string) error {
-	err := handler.K8sClient.CycloneV1alpha1().Workflows(common.TenantNamespace(tenant)).Delete(workflow, nil)
+	err := deleteCollections(tenant, project, workflow)
+	if err != nil {
+		return err
+	}
 
+	err = handler.K8sClient.CycloneV1alpha1().Workflows(common.TenantNamespace(tenant)).Delete(workflow, nil)
 	return cerr.ConvertK8sError(err)
 
 }

--- a/pkg/server/handler/v1alpha1/workflowrun.go
+++ b/pkg/server/handler/v1alpha1/workflowrun.go
@@ -169,8 +169,12 @@ func UpdateWorkflowRun(ctx context.Context, project, workflow, workflowrun, tena
 
 // DeleteWorkflowRun ...
 func DeleteWorkflowRun(ctx context.Context, project, workflow, workflowrun, tenant string) error {
-	err := handler.K8sClient.CycloneV1alpha1().WorkflowRuns(common.TenantNamespace(tenant)).Delete(workflowrun, nil)
+	err := deleteCollections(tenant, project, workflow, workflowrun)
+	if err != nil {
+		return err
+	}
 
+	err = handler.K8sClient.CycloneV1alpha1().WorkflowRuns(common.TenantNamespace(tenant)).Delete(workflowrun, nil)
 	return cerr.ConvertK8sError(err)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Delete logs in PVC while deleting associated cyclone resources, including:
- tenant
- project
- workflow
- workflowrun

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
