### PR TITLE
fix: add project owner reference

### DIFF
--- a/pkg/server/handler/v1alpha1/resource.go
+++ b/pkg/server/handler/v1alpha1/resource.go
@@ -17,7 +17,7 @@ import (
 
 // CreateResource ...
 func CreateResource(ctx context.Context, project, tenant string, rsc *v1alpha1.Resource) (*v1alpha1.Resource, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectProjectOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, "", rsc)
 		if err != nil {

--- a/pkg/server/handler/v1alpha1/stage.go
+++ b/pkg/server/handler/v1alpha1/stage.go
@@ -17,7 +17,7 @@ import (
 
 // CreateStage ...
 func CreateStage(ctx context.Context, project, tenant string, stg *v1alpha1.Stage) (*v1alpha1.Stage, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectProjectOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, "", stg)
 		if err != nil {

--- a/pkg/server/handler/v1alpha1/workflow.go
+++ b/pkg/server/handler/v1alpha1/workflow.go
@@ -20,7 +20,7 @@ import (
 
 // CreateWorkflow ...
 func CreateWorkflow(ctx context.Context, tenant, project string, wf *v1alpha1.Workflow) (*v1alpha1.Workflow, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectProjectOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, "", wf)
 		if err != nil {

--- a/pkg/server/handler/v1alpha1/workflowtrigger.go
+++ b/pkg/server/handler/v1alpha1/workflowtrigger.go
@@ -18,7 +18,7 @@ import (
 
 // CreateWorkflowTrigger ...
 func CreateWorkflowTrigger(ctx context.Context, project, tenant string, wft *v1alpha1.WorkflowTrigger) (*v1alpha1.WorkflowTrigger, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectProjectOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, "", wft)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add owner reference for project sub-resources:
- workflow
- stage
- resource
- workflow trigger

so when a project was deleted, it's sub-resources will be deleted too.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
