### PR TITLE
fix: apply correct resource requirements

### DIFF
--- a/pkg/workflow/workload/pod/builder.go
+++ b/pkg/workflow/workload/pod/builder.go
@@ -760,14 +760,13 @@ func applyResourceRequirements(containers []corev1.Container, requirements *core
 // - In the Workflow Controller configurations as default values.
 // So requirements set in stage spec would have the highest priority.
 func (m *Builder) ApplyResourceRequirements() error {
-	// Apply resource requirements from Workflow spec.
+	requirements := &controller.Config.ResourceRequirements
 	if m.wf.Spec.Resources != nil {
-		m.pod.Spec.Containers = applyResourceRequirements(m.pod.Spec.Containers, m.wf.Spec.Resources, common.OnlyCustomContainer)
+		requirements = m.wf.Spec.Resources
 	}
 
-	// Apply default resource requirements from Workflow Controller configuration.
-	m.pod.Spec.InitContainers = applyResourceRequirements(m.pod.Spec.InitContainers, &controller.Config.ResourceRequirements, common.AllContainers)
-	m.pod.Spec.Containers = applyResourceRequirements(m.pod.Spec.Containers, &controller.Config.ResourceRequirements, common.AllContainers)
+	m.pod.Spec.InitContainers = applyResourceRequirements(m.pod.Spec.InitContainers, requirements, common.AllContainers)
+	m.pod.Spec.Containers = applyResourceRequirements(m.pod.Spec.Containers, requirements, common.AllContainers)
 
 	return nil
 }

--- a/pkg/workflow/workload/pod/builder_test.go
+++ b/pkg/workflow/workload/pod/builder_test.go
@@ -500,7 +500,7 @@ func (suite *PodBuilderSuite) TestApplyResourceRequirements() {
 
 	assert.Nil(suite.T(), builder.ApplyResourceRequirements())
 	for _, c := range builder.pod.Spec.InitContainers {
-		assert.Equal(suite.T(), configured, c.Resources)
+		assert.Equal(suite.T(), wf.Spec.Resources, &c.Resources)
 	}
 
 	for _, c := range builder.pod.Spec.Containers {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Fix the problem that resource requirements set in wf spec is not used problem.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
