### PR TITLE
fix: should collect input resources logs

### DIFF
--- a/pkg/workflow/coordinator/coordinator.go
+++ b/pkg/workflow/coordinator/coordinator.go
@@ -90,9 +90,9 @@ func NewCoordinator(client clientset.Interface) (*Coordinator, error) {
 	}, nil
 }
 
-// CollectLogs collects all containers' logs except for the coordinator container itself.
+// CollectLogs collects all containers' logs.
 func (co *Coordinator) CollectLogs() error {
-	cs, err := co.getAllOtherContainers()
+	cs, err := co.getAllContainers()
 	if err != nil {
 		return err
 	}
@@ -313,17 +313,18 @@ func (co *Coordinator) NotifyResolvers() error {
 	return nil
 }
 
-func (co *Coordinator) getAllOtherContainers() ([]string, error) {
+func (co *Coordinator) getAllContainers() ([]string, error) {
 	var cs []string
 	pod, err := co.runtimeExec.GetPod()
 	if err != nil {
 		return cs, err
 	}
 
+	for _, c := range pod.Spec.InitContainers {
+		cs = append(cs, c.Name)
+	}
 	for _, c := range pod.Spec.Containers {
-		if c.Name != common.CoordinatorSidecarName {
-			cs = append(cs, c.Name)
-		}
+		cs = append(cs, c.Name)
 	}
 
 	return cs, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Collect logs of init-containers and coordinator itself.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Partially Fixes #929 

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
