### PR TITLE
fix: wrong ref of wfr triggered by scm tag release

### DIFF
--- a/pkg/server/biz/scm/gitlab/gitlab.go
+++ b/pkg/server/biz/scm/gitlab/gitlab.go
@@ -443,7 +443,7 @@ func ParseEvent(request *http.Request) *scm.EventData {
 		return &scm.EventData{
 			Type: scm.TagReleaseEventType,
 			Repo: event.Project.PathWithNamespace,
-			Ref:  strings.Split(event.Ref, "/")[2],
+			Ref:  event.Ref,
 		}
 	case *gitlab.MergeEvent:
 		objectAttributes := event.ObjectAttributes

--- a/pkg/server/handler/v1alpha1/webhook.go
+++ b/pkg/server/handler/v1alpha1/webhook.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/caicloud/nirvana/log"
 	"github.com/caicloud/nirvana/service"
@@ -115,6 +116,10 @@ func createWorkflowRun(tenant, wftName string, data *scm.EventData) error {
 		if st.TagRelease.Enabled {
 			trigger = true
 			tag = data.Ref
+			splitTags := strings.Split(data.Ref, "/")
+			if len(splitTags) == 3 {
+				tag = splitTags[2]
+			}
 		}
 	case scm.PushEventType:
 		for _, branch := range st.Push.Branches {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Ref of workflow run triggered by scm tag release, shold be `refs/tags/{tagName}`, but it is `{tagName}`

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
