### PR TITLE
improve: make open control cluster configurable

### DIFF
--- a/manifests/cyclone.yaml.template
+++ b/manifests/cyclone.yaml.template
@@ -72,6 +72,7 @@ data:
       "create_builtin_templates": true,
       "system_namespace": "default",
       "init_default_tenant": true,
+      "open_control_cluster": true,
       "storage_usage_watcher": {
         "image": "__REGISTRY__/cyclone-watcher:__VERSION__",
         "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storage/usages",

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -50,6 +50,9 @@ type CycloneServerConfig struct {
 	// InitDefaultTenant configures whether to create cyclone default tenant while cyclone server start up.
 	InitDefaultTenant bool `json:"init_default_tenant"`
 
+	// OpenControlCluster indicates whether to open control cluster for workflow execution when tenant created
+	OpenControlCluster bool `json:"open_control_cluster"`
+
 	// Images that used in cyclone, such as GC image.
 	Images map[string]string `json:"images"`
 

--- a/pkg/server/handler/v1alpha1/tenant.go
+++ b/pkg/server/handler/v1alpha1/tenant.go
@@ -295,9 +295,16 @@ func createControlClusterIntegration(tenant string) error {
 		},
 	}
 
-	_, err := createIntegration(tenant, in)
+	in, err := createIntegration(tenant, in)
 	if err != nil {
 		return cerr.ErrorCreateIntegration.Error(err)
+	}
+
+	if config.Config.OpenControlCluster {
+		err := OpenClusterForTenant(in, tenant)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/release/cyclone-server.yaml
+++ b/release/cyclone-server.yaml
@@ -80,6 +80,7 @@ _config:
             "create_builtin_templates": false,
             "system_namespace": "default",
             "init_default_tenant": false,
+            "open_control_cluster": false,
             "storage_usage_watcher": {
               "image": "[[ registry_release ]]/cyclone-watcher:[[ imageTagFromGitTag ]]",
               "report_url": "http://cyclone-server.default.svc.cluster.local:7099/apis/v1alpha1/storage/usages",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Make it configurable to open control cluster for workflow execution. So that, we can deploy cyclone with everything ready for workflow execution.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
