### PR TITLE
fix: tag does not take effect when there is a default value

### DIFF
--- a/pkg/server/handler/v1alpha1/webhook.go
+++ b/pkg/server/handler/v1alpha1/webhook.go
@@ -115,12 +115,12 @@ func createWorkflowRun(tenant, wftName string, data *scm.EventData) error {
 		project = wft.Labels[meta.LabelProjectName]
 	}
 	if project == "" {
-		return fmt.Errorf("Failed to get project from workflowtrigger labels")
+		return fmt.Errorf("failed to get project from workflowtrigger labels")
 	}
 
 	wfName := wft.Spec.WorkflowRef.Name
 	if wfName == "" {
-		return fmt.Errorf("Workflow reference of workflowtrigger is empty")
+		return fmt.Errorf("workflow reference of workflowtrigger is empty")
 	}
 
 	trigger := false
@@ -188,14 +188,14 @@ func createWorkflowRun(tenant, wftName string, data *scm.EventData) error {
 		return err
 	}
 
-	// Set "Tag" and "SCM_REVISION" for all resource configs if they are empty.
+	// Set "Tag" and "SCM_REVISION" for all resource configs.
 	for _, r := range wft.Spec.WorkflowRunSpec.Resources {
 		for i, p := range r.Parameters {
-			if p.Name == "TAG" && (p.Value == nil || *p.Value == "") {
+			if p.Name == "TAG" && tag != "" {
 				r.Parameters[i].Value = &tag
 			}
 
-			if p.Name == "SCM_REVISION" && (p.Value == nil || *p.Value == "") {
+			if p.Name == "SCM_REVISION" && data.Ref != "" {
 				r.Parameters[i].Value = &data.Ref
 			}
 		}
@@ -204,7 +204,7 @@ func createWorkflowRun(tenant, wftName string, data *scm.EventData) error {
 	// Set "Tag" for all stage configs.
 	for _, s := range wft.Spec.WorkflowRunSpec.Stages {
 		for i, p := range s.Parameters {
-			if p.Name == "tag" && (p.Value == nil || *p.Value == "") {
+			if p.Name == "tag" && tag != "" {
 				s.Parameters[i].Value = &tag
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

With SCM triggered pipeline, `TAG` and `SCM_REVISION` does not take effect when there is a default value,e.g. `latest` for `TAG` and `refs/heads/master` for `SCM_REVISION`.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
