### PR TITLE
Create default ExecutionCluster CR for control cluster

### DIFF
--- a/cmd/workflow/controller/main.go
+++ b/cmd/workflow/controller/main.go
@@ -44,8 +44,11 @@ func main() {
 		log.WithField("configmap", *cm).Fatal("Load config from ConfigMap error: ", err)
 	}
 
-	// Init logging system.
+	// Init logging and control cluster
 	controller.InitLogger(&controller.Config.Logging)
+	if err = controller.InitControlCluster(client); err != nil {
+		log.Fatal("Init control cluster error: ", err)
+	}
 
 	// create CRD
 	v1alpha1.EnsureCRDCreated("", *kubeConfigPath)

--- a/pkg/workflow/common/cluster.go
+++ b/pkg/workflow/common/cluster.go
@@ -11,7 +11,7 @@ import (
 // GetExecutionClusterClient gets execution cluster client with the WorkflowRun
 func GetExecutionClusterClient(wfr *v1alpha1.WorkflowRun) kubernetes.Interface {
 	cluster := common.ControlClusterName
-	if wfr.Spec.ExecutionContext != nil {
+	if wfr.Spec.ExecutionContext != nil && wfr.Spec.ExecutionContext.Cluster != "" {
 		cluster = wfr.Spec.ExecutionContext.Cluster
 	}
 

--- a/pkg/workflow/controller/init.go
+++ b/pkg/workflow/controller/init.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	"github.com/caicloud/cyclone/pkg/common"
+	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 )
 
 // InitLogger inits logging
@@ -30,4 +36,24 @@ func InitLogger(logging *LoggingConfig) {
 		FullTimestamp: true,
 	})
 	log.SetOutput(os.Stdout)
+}
+
+// InitControlCluster initializes control cluster for workflow to run.
+func InitControlCluster(client clientset.Interface) error {
+	// Create ExecutionCluster instance for control cluster. This makes it possible to
+	// use only workflow engine to run workflow in control cluster.
+	// Create ExecutionCluster resource for Workflow Engine to use
+	_, err := client.CycloneV1alpha1().ExecutionClusters().Create(&v1alpha1.ExecutionCluster{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: common.ControlClusterName,
+		},
+	})
+
+	// If the CR already exists, just ignore it.
+	if err != nil && errors.IsAlreadyExists(err) {
+		log.Infof("ExecutionCluster resource '%s' already exist", common.ControlClusterName)
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

In the case what use only workflow engine, we need to enable execution cluster for the control cluster.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
