### PR TITLE
feat: support multiple workflow controller

### DIFF
--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -13,4 +13,7 @@ const (
 
 	// ControlClusterName is name of the master cluster
 	ControlClusterName = "cyclone-control-cluster"
+
+	// ControllerInstanceEnvName is environment name for workflow controller instance
+	ControllerInstanceEnvName = "CONTROLLER_INSTANCE_NAME"
 )

--- a/pkg/workflow/controller/controllers/workflowrun.go
+++ b/pkg/workflow/controller/controllers/workflowrun.go
@@ -3,11 +3,13 @@ package controllers
 import (
 	"reflect"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/k8s/informers"
+	"github.com/caicloud/cyclone/pkg/meta"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
 	"github.com/caicloud/cyclone/pkg/workflow/controller"
 	handlers "github.com/caicloud/cyclone/pkg/workflow/controller/handlers/workflowrun"
@@ -17,9 +19,12 @@ import (
 // NewWorkflowRunController ...
 func NewWorkflowRunController(client clientset.Interface) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	factory := informers.NewSharedInformerFactory(
+	factory := informers.NewSharedInformerFactoryWithOptions(
 		client,
 		common.ResyncPeriod,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = meta.WorkflowRunSelector()
+		}),
 	)
 
 	informer := factory.Cyclone().V1alpha1().WorkflowRuns().Informer()

--- a/pkg/workflow/controller/handlers/workflowtrigger/cron_job.go
+++ b/pkg/workflow/controller/handlers/workflowtrigger/cron_job.go
@@ -2,6 +2,7 @@ package workflowtrigger
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -12,9 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	ccommon "github.com/caicloud/cyclone/pkg/common"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
-	common "github.com/caicloud/cyclone/pkg/server/common"
+	"github.com/caicloud/cyclone/pkg/server/common"
 )
 
 const (
@@ -129,6 +131,11 @@ func (m *CronTriggerManager) CreateCron(wft *v1alpha1.WorkflowTrigger) {
 			},
 		},
 		Spec: wft.Spec.WorkflowRunSpec,
+	}
+
+	// If controller instance name is set, add label to the pod created.
+	if instance := os.Getenv(ccommon.ControllerInstanceEnvName); len(instance) != 0 {
+		wfr.ObjectMeta.Labels[meta.LabelControllerInstance] = instance
 	}
 
 	if wft.Labels != nil {

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -2,6 +2,7 @@ package workflowrun
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	ccommon "github.com/caicloud/cyclone/pkg/common"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
@@ -472,6 +474,11 @@ func (o *operator) GC(lastTry, wfrDeletion bool) error {
 					},
 				},
 			},
+		}
+
+		// If controller instance name is set, add label to the pod created.
+		if instance := os.Getenv(ccommon.ControllerInstanceEnvName); len(instance) != 0 {
+			gcPod.ObjectMeta.Labels[meta.LabelControllerInstance] = instance
 		}
 
 		_, err := o.clusterClient.CoreV1().Pods(executionContext.Namespace).Create(gcPod)

--- a/pkg/workflow/workload/pod/builder.go
+++ b/pkg/workflow/workload/pod/builder.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	ccommon "github.com/caicloud/cyclone/pkg/common"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
@@ -79,6 +80,11 @@ func (m *Builder) Prepare() error {
 			meta.AnnotationStageName:       m.stage,
 			meta.AnnotationMetaNamespace:   m.wfr.Namespace,
 		},
+	}
+
+	// If controller instance name is set, add label to the pod created.
+	if instance := os.Getenv(ccommon.ControllerInstanceEnvName); len(instance) != 0 {
+		m.pod.ObjectMeta.Labels[meta.LabelControllerInstance] = instance
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add controller instance id to workflow controller. If instance set, controllers for `pod`, `workflowrun`, `workflowruntrigger` will only watch resources with the correct instance label. And pod, wfr created by the workflow controller will also have controller instance label set.

To keep back-compatibility, if no instance id set, no label would be applied, and controllers would watch resources without the controller instance label.

Note: only workflow controller supports multiple instance. Cyclone sever would ignore the controller instance label.

To set instance id, set environment variable `CONTROLLER_INSTANCE_NAME`, for example: `cyclone`

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
