### PR TITLE
[Web] feat: open/close cluster in integration center

### DIFF
--- a/web/src/api/index.js
+++ b/web/src/api/index.js
@@ -43,6 +43,12 @@ const fetchApi = {
   removeIntegration(name) {
     return http.delete(`/integrations/${name}`);
   },
+  openCluster(name) {
+    return http.put(`/integrations/${name}/opencluster`, null);
+  },
+  closeCluster(name) {
+    return http.put(`/integrations/${name}/closecluster`, null);
+  },
   fetchResources() {
     return http.get('/resources').then(data => {
       return data;

--- a/web/src/components/integration/component/detail/index.js
+++ b/web/src/components/integration/component/detail/index.js
@@ -1,4 +1,4 @@
-import { Spin } from 'antd';
+import { Spin, Button, Icon, Modal } from 'antd';
 import { inject, observer } from 'mobx-react';
 import Detail from '@/components/public/detail';
 import PropTypes from 'prop-types';
@@ -75,13 +75,21 @@ class IntegrationDetail extends React.Component {
             <DetailHeadItem
               name={intl.get('integration.form.cluster.isControlCluster')}
               value={
-                _.get(detail, 'spec.cluster.isControlCluster') ? 'YES' : 'NO'
+                _.get(detail, 'spec.cluster.isControlCluster') ? (
+                  <Icon type="check" style={{ color: '#1890ff' }} />
+                ) : (
+                  <Icon type="minus" />
+                )
               }
             />
             <DetailHeadItem
               name={intl.get('integration.form.cluster.isWorkerCluster')}
               value={
-                _.get(detail, 'spec.cluster.isWorkerCluster') ? 'YES' : 'NO'
+                _.get(detail, 'spec.cluster.isWorkerCluster') ? (
+                  <Icon type="check" style={{ color: '#1890ff' }} />
+                ) : (
+                  <Icon type="minus" />
+                )
               }
             />
           </div>
@@ -89,6 +97,26 @@ class IntegrationDetail extends React.Component {
       default:
         return <div />;
     }
+  };
+
+  openCluster = () => {
+    const { integrationDetail, openCluster } = this.props.integration;
+    Modal.confirm({
+      title: intl.get('cluster.openTips'),
+      onOk() {
+        openCluster(integrationDetail.metadata.name);
+      },
+    });
+  };
+
+  closeCluster = () => {
+    const { integrationDetail, closeCluster } = this.props.integration;
+    Modal.confirm({
+      title: intl.get('cluster.closeTips'),
+      onOk() {
+        closeCluster(integrationDetail.metadata.name);
+      },
+    });
   };
 
   render() {
@@ -100,15 +128,31 @@ class IntegrationDetail extends React.Component {
       history,
     } = this.props;
     const loading = integration.detailLoading;
-    if (loading) {
+    const processing = integration.processing;
+    if (loading || processing) {
       return <Spin />;
     }
     const detail = integration.integrationDetail;
+    const opened =
+      _.get(
+        detail,
+        'metadata.labels["integration.cyclone.dev/schedulable-cluster"]'
+      ) === 'true';
 
     return (
       <Detail
         actions={
           <DetailAction>
+            {_.get(detail, 'spec.type') === 'Cluster' && (
+              <Button
+                type="primary"
+                size="small"
+                style={{ marginRight: 16 }}
+                onClick={opened ? this.closeCluster : this.openCluster}
+              >
+                {opened ? intl.get('cluster.close') : intl.get('cluster.open')}
+              </Button>
+            )}
             <MenuAction name={integrationName} history={history} detail />
           </DetailAction>
         }

--- a/web/src/locale/en-US.yaml
+++ b/web/src/locale/en-US.yaml
@@ -20,6 +20,11 @@ key: Key
 custom: Custom
 tips:
   officialWebsite: Open Cyclone official website for docs and guides
+cluster:
+  open: Open
+  openTips: Sure to initialize this cluster for current tenant to execution workflow ?
+  close: Close
+  closeTips: Sure to cleanup this cluster for current tenant ? After this operation, current tenant can't execute workflow in this cluster.
 operation:
   add: Add
   delete: Delete

--- a/web/src/locale/zh-CN.yaml
+++ b/web/src/locale/zh-CN.yaml
@@ -20,6 +20,11 @@ key: 健
 custom: 自定义
 tips:
   officialWebsite: 访问 Cyclone 官网查看项目文档和使用说明
+cluster:
+  open: 开启
+  openTips: 确定为租户初始化该集群以便运行流水线?
+  close: 关闭
+  closeTips: 确定为租户清理该集群？该操作后租户无法继续该集群运行流水线
 operation:
   add: 新增
   delete: 删除

--- a/web/src/store/integration.js
+++ b/web/src/store/integration.js
@@ -11,6 +11,7 @@ class Integration {
   };
   @observable integrationDetail = null;
   @observable detailLoading = false;
+  @observable processing = false;
 
   @action.bound
   getIntegrationList() {
@@ -69,6 +70,20 @@ class Integration {
     fetchApi.getIntegration(name).then(data => {
       this.integrationDetail = data;
       this.detailLoading = false;
+    });
+  }
+  @action.bound
+  closeCluster(name) {
+    this.processing = true;
+    fetchApi.closeCluster(name).then(data => {
+      this.processing = false;
+    });
+  }
+  @action.bound
+  openCluster(name) {
+    this.processing = true;
+    fetchApi.openCluster(name).then(data => {
+      this.processing = false;
     });
   }
   @action.bound


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Open/Close cluster in integration cluster.

![image](https://user-images.githubusercontent.com/16573984/57788705-1f7c7680-776a-11e9-896f-25336162232c.png)

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @huxiangtao @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
