### PR TITLE
fix(stageTemplate): fix array input blur with dynamic field key

### DIFF
--- a/web/src/components/stageTemplate/add/Config.js
+++ b/web/src/components/stageTemplate/add/Config.js
@@ -78,7 +78,7 @@ const ConfigSection = props => {
                           <Row key={i} gutter={16}>
                             <Col span={11}>
                               <Field
-                                key={a.name}
+                                key={i}
                                 name={`spec.pod.spec.containers.${index}.env.${i}.name`}
                                 component={InputField}
                                 hasFeedback
@@ -86,7 +86,7 @@ const ConfigSection = props => {
                             </Col>
                             <Col span={11}>
                               <Field
-                                key={a.value}
+                                key={i}
                                 name={`spec.pod.spec.containers.${index}.env.${i}.value`}
                                 component={InputField}
                                 hasFeedback

--- a/web/src/components/stageTemplate/add/Output.js
+++ b/web/src/components/stageTemplate/add/Output.js
@@ -35,7 +35,7 @@ const OutputSection = props => {
                   <Row key={index} gutter={16}>
                     <Col span={11}>
                       <Field
-                        key={a.name}
+                        key={index}
                         name={`spec.pod.outputs.artifacts.${index}.name`}
                         component={InputField}
                         hasFeedback
@@ -43,7 +43,7 @@ const OutputSection = props => {
                     </Col>
                     <Col span={11}>
                       <Field
-                        key={a.value}
+                        key={index}
                         name={`spec.pod.outputs.artifacts.${index}.path`}
                         component={InputField}
                         hasFeedback


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

fix Input box loses focus problem
![image](https://user-images.githubusercontent.com/3294535/58142395-71952e80-7c79-11e9-97a0-6acccbf40168.png)


**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @qiuxiaolian 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
