### PR TITLE
feat: support generation type values in argument

### DIFF
--- a/pkg/common/values/generators.go
+++ b/pkg/common/values/generators.go
@@ -1,0 +1,38 @@
+package values
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// Generator is used to generate specific type of string value, for example, fixed length random string, timestamp.
+type Generator interface {
+	// Value generates a string value according to params. How params is interpreted is determined by the generator implementation.
+	Value(interface{}) string
+	// Parse parses input string that represents a specific type value. For example, a given length random
+	// string. If the input is not a valid given type ref value, the origin input value is returned.
+	Parse(v string) string
+}
+
+var (
+	// RandomString is used to generate a random string
+	RandomString Generator
+	// NowTimeString is used to generate current timestamp
+	NowTimeString Generator
+)
+
+func init() {
+	RandomString = &randomString{stringGenerator: rand.String}
+	NowTimeString = &nowTimeString{nowTimeGetter: time.Now}
+}
+
+// ParseRefValue passes through the input value to all the supported value generators to get the final value. For example,
+// $RANDOM:5 --> xafce
+// $NOWTIME:RFC3339 --> 2019-05-24T11:10:13+08:00
+func ParseRefValue(value string) string {
+	value = RandomString.Parse(value)
+	value = NowTimeString.Parse(value)
+
+	return value
+}

--- a/pkg/common/values/generators_test.go
+++ b/pkg/common/values/generators_test.go
@@ -1,0 +1,48 @@
+package values
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRefValue(t *testing.T) {
+	RandomString = &randomString{stringGenerator: stringGenerator}
+	NowTimeString = &nowTimeString{
+		nowTimeGetter: Now,
+	}
+
+	cases := []struct {
+		Origin   string
+		Expected string
+	}{
+		{
+			"",
+			"",
+		},
+		{
+			"aaa",
+			"aaa",
+		},
+		{
+			"$RANDOM:1",
+			"A",
+		},
+		{
+			"$RANDOM:2",
+			"BB",
+		},
+		{
+			"$RANDOM:x",
+			"$RANDOM:x",
+		},
+		{
+			"$TIMENOW:RFC3339",
+			"2019-05-24T11:10:13+08:00",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.Expected, ParseRefValue(c.Origin))
+	}
+}

--- a/pkg/common/values/nowtime.go
+++ b/pkg/common/values/nowtime.go
@@ -1,0 +1,71 @@
+package values
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+var formatLayouts = map[string]string{
+	"ANSIC":       "Mon Jan _2 15:04:05 2006",
+	"UnixDate":    "Mon Jan _2 15:04:05 MST 2006",
+	"RubyDate":    "Mon Jan 02 15:04:05 -0700 2006",
+	"RFC822":      "02 Jan 06 15:04 MST",
+	"RFC822Z":     "02 Jan 06 15:04 -0700",
+	"RFC850":      "Monday, 02-Jan-06 15:04:05 MST",
+	"RFC1123":     "Mon, 02 Jan 2006 15:04:05 MST",
+	"RFC1123Z":    "Mon, 02 Jan 2006 15:04:05 -0700",
+	"RFC3339":     "2006-01-02T15:04:05Z07:00",
+	"RFC3339Nano": "2006-01-02T15:04:05.999999999Z07:00",
+	"Kitchen":     "3:04PM",
+	"Stamp":       "Jan _2 15:04:05",
+	"StampMilli":  "Jan _2 15:04:05.000",
+	"StampMicro":  "Jan _2 15:04:05.000000",
+	"StampNano":   "Jan _2 15:04:05.000000000",
+}
+
+type nowTimeString struct {
+	nowTimeGetter func() time.Time
+}
+
+type NowTimeStringParam struct {
+	Format string `json:"format"`
+}
+
+// Value generates timestamp string for current time based on the input params.
+func (t *nowTimeString) Value(param interface{}) string {
+	switch v := param.(type) {
+	case string:
+		return t.Parse(v)
+	case NowTimeStringParam:
+		return t.value(&v)
+	case *NowTimeStringParam:
+		return t.value(v)
+	default:
+		return t.value(&NowTimeStringParam{})
+	}
+}
+
+func (t *nowTimeString) value(param *NowTimeStringParam) string {
+	if len(param.Format) == 0 {
+		return strconv.FormatInt(t.nowTimeGetter().Unix(), 10)
+	}
+
+	if layout, ok := formatLayouts[param.Format]; ok {
+		return t.nowTimeGetter().Format(layout)
+	}
+
+	return t.nowTimeGetter().Format(param.Format)
+}
+
+// Parse parses now time string value from a string. If the input string is a valid now time string
+// ref value: $TIMENOW:<format>, for example: $TIMENOW:RFC1123, then the formatted now time, otherwise
+// return the input string itself.
+func (t *nowTimeString) Parse(v string) string {
+	trimed := strings.TrimSpace(v)
+	if !strings.HasPrefix(trimed, "$TIMENOW:") {
+		return v
+	}
+
+	return t.Value(&NowTimeStringParam{Format: strings.TrimPrefix(trimed, "$TIMENOW:")})
+}

--- a/pkg/common/values/nowtime_test.go
+++ b/pkg/common/values/nowtime_test.go
@@ -1,0 +1,49 @@
+package values
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Now() time.Time {
+	t, _ := time.Parse(time.RFC3339, "2019-05-24T11:10:13+08:00")
+	return t
+}
+
+func TestNowTimeValue(t *testing.T) {
+	generator := &nowTimeString{
+		nowTimeGetter: Now,
+	}
+
+	cases := []struct {
+		Params   interface{}
+		Expected string
+	}{
+		{
+			NowTimeStringParam{},
+			"1558667413",
+		},
+		{
+			NowTimeStringParam{Format: time.RFC3339},
+			"2019-05-24T11:10:13+08:00",
+		},
+		{
+			"2019-05-24T11:10:13+08:00",
+			"2019-05-24T11:10:13+08:00",
+		},
+		{
+			"$TIMENOW:RFC3339",
+			"2019-05-24T11:10:13+08:00",
+		},
+		{
+			"aaaaa",
+			"aaaaa",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.Expected, generator.Value(c.Params))
+	}
+}

--- a/pkg/common/values/random.go
+++ b/pkg/common/values/random.go
@@ -1,0 +1,58 @@
+package values
+
+import (
+	"strconv"
+	"strings"
+)
+
+type randomString struct {
+	stringGenerator func(int) string
+}
+
+type RandomValueParam struct {
+	Length int `json:"length"`
+}
+
+// Value generates random string value based on the input params.
+func (r *randomString) Value(param interface{}) string {
+	switch v := param.(type) {
+	case int:
+		return r.value(&RandomValueParam{Length: v})
+	case int64:
+		return r.value(&RandomValueParam{Length: int(v)})
+	case string:
+		return r.Parse(v)
+	case RandomValueParam:
+		return r.value(&v)
+	case *RandomValueParam:
+		return r.value(v)
+	default:
+		return ""
+	}
+}
+
+func (r *randomString) value(param *RandomValueParam) string {
+	if param.Length <= 0 {
+		return ""
+	}
+
+	return r.stringGenerator(param.Length)
+}
+
+// Parse parses random values from a string. If the input string is a valid random value ref
+// value: $RANDOM:<length>, for example: $RANDOM:5, then generate a random value accordingly,
+// otherwise return the input string itself.
+func (r *randomString) Parse(v string) string {
+	trimed := strings.TrimSpace(v)
+	if !strings.HasPrefix(trimed, "$RANDOM:") {
+		return v
+	}
+
+	p := strings.TrimPrefix(trimed, "$RANDOM:")
+	length, err := strconv.ParseInt(p, 10, 32)
+	if err != nil {
+		return v
+	}
+
+	return r.Value(length)
+}

--- a/pkg/common/values/random_test.go
+++ b/pkg/common/values/random_test.go
@@ -1,0 +1,54 @@
+package values
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func stringGenerator(length int) string {
+	if length%2 != 0 {
+		return strings.Repeat("A", length)
+	}
+
+	return strings.Repeat("B", length)
+}
+
+func TestRandomValue(t *testing.T) {
+	generator := &randomString{stringGenerator: stringGenerator}
+
+	cases := []struct {
+		Params   interface{}
+		Expected string
+	}{
+		{
+			5,
+			"AAAAA",
+		},
+		{
+			RandomValueParam{Length: 4},
+			"BBBB",
+		},
+		{
+			&RandomValueParam{Length: 3},
+			"AAA",
+		},
+		{
+			1.5,
+			"",
+		},
+		{
+			"value",
+			"value",
+		},
+		{
+			"$RANDOM:7",
+			"AAAAAAA",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.Expected, generator.Value(c.Params))
+	}
+}

--- a/pkg/workflow/workload/pod/builder.go
+++ b/pkg/workflow/workload/pod/builder.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	ccommon "github.com/caicloud/cyclone/pkg/common"
+	"github.com/caicloud/cyclone/pkg/common/values"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
@@ -115,6 +116,7 @@ func (m *Builder) ResolveArguments() error {
 	}
 
 	for k, v := range parameters {
+		v = values.ParseRefValue(v)
 		resolved, err := ResolveRefStringValue(v, m.client)
 		if err != nil {
 			log.WithField("key", k).WithField("value", v).Error("resolve ref failed:", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Support two new argument value type:

- NowTimeString
- RandomString

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
