### PR TITLE
fix: list workflow triggers belonged to the specific workflow

### DIFF
--- a/pkg/server/handler/v1alpha1/helper.go
+++ b/pkg/server/handler/v1alpha1/helper.go
@@ -341,19 +341,24 @@ func InjectWorkflowOwnerRefModifier(tenant, project, wf string, object interface
 	return nil
 }
 
-// WorkflowRunModifier is a modifier of create cyclone workflowrun resources.
-// It will add workflow labels for workflowrun.
-func WorkflowRunModifier(tenant, project, wf string, object interface{}) error {
-	wfr, ok := object.(*v1alpha1.WorkflowRun)
-	if !ok {
+// InjectWorkflowLabelModifier is a modifier of create cyclone CRD resources.
+// It will add workflow labels for the resource.
+func InjectWorkflowLabelModifier(tenant, project, wf string, object interface{}) error {
+	var objectMeta *meta_v1.ObjectMeta
+	switch obj := object.(type) {
+	case *v1alpha1.WorkflowRun:
+		objectMeta = &obj.ObjectMeta
+	case *v1alpha1.WorkflowTrigger:
+		objectMeta = &obj.ObjectMeta
+	default:
 		return fmt.Errorf("resource type not support")
 	}
 
 	// Add workflow label
-	if wfr.Labels == nil {
-		wfr.Labels = make(map[string]string)
+	if objectMeta.Labels == nil {
+		objectMeta.Labels = make(map[string]string)
 	}
-	wfr.Labels[meta.LabelWorkflowName] = wf
+	objectMeta.Labels[meta.LabelWorkflowName] = wf
 	return nil
 }
 

--- a/pkg/server/handler/v1alpha1/workflowrun.go
+++ b/pkg/server/handler/v1alpha1/workflowrun.go
@@ -36,7 +36,7 @@ import (
 
 // CreateWorkflowRun ...
 func CreateWorkflowRun(ctx context.Context, project, workflow, tenant string, wfr *v1alpha1.WorkflowRun) (*v1alpha1.WorkflowRun, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectWorkflowOwnerRefModifier, WorkflowRunModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectWorkflowLabelModifier, InjectWorkflowOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, workflow, wfr)
 		if err != nil {

--- a/pkg/server/handler/v1alpha1/workflowtrigger.go
+++ b/pkg/server/handler/v1alpha1/workflowtrigger.go
@@ -22,7 +22,7 @@ import (
 
 // CreateWorkflowTrigger ...
 func CreateWorkflowTrigger(ctx context.Context, tenant, project, workflow string, wft *v1alpha1.WorkflowTrigger) (*v1alpha1.WorkflowTrigger, error) {
-	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectWorkflowOwnerRefModifier}
+	modifiers := []CreationModifier{GenerateNameModifier, InjectProjectLabelModifier, InjectWorkflowLabelModifier, InjectWorkflowOwnerRefModifier}
 	for _, modifier := range modifiers {
 		err := modifier(tenant, project, workflow, wft)
 		if err != nil {
@@ -48,7 +48,7 @@ func CreateWorkflowTrigger(ctx context.Context, tenant, project, workflow string
 // ListWorkflowTriggers ...
 func ListWorkflowTriggers(ctx context.Context, tenant, project, workflow string, query *types.QueryParams) (*types.ListResponse, error) {
 	workflowTriggers, err := handler.K8sClient.CycloneV1alpha1().WorkflowTriggers(common.TenantNamespace(tenant)).List(metav1.ListOptions{
-		LabelSelector: meta.ProjectSelector(project),
+		LabelSelector: meta.ProjectSelector(project) + "," + meta.WorkflowSelector(workflow),
 	})
 	if err != nil {
 		log.Errorf("Get workflowtrigger from k8s with tenant %s, project %s error: %v", tenant, project, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

The list wfts API listed all workflow triggers and did not filter triggers that do not belong to the specific workflow. fix that.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
