### PR TITLE
fix(git-resolver): encode token string

### DIFF
--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -94,7 +94,8 @@ modifyURL() {
     # If URL contains '@', for example: http://root@192.168.21.97/scm/foobar.git, change
     # url to http://root:<auth>@192.168.21.97/scm/foobar.git
     if [[ "${URL%%@*}" != "${URL}" ]]; then
-        echo ${URL/@/:${2}@}
+        local encoded=$(urlencode "${2}")
+        echo ${URL/@/:${encoded}@}
     else
         echo ${URL/\/\//\/\/${AUTH}@}
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Fix git resolver clone bitbucket code error:
```
fatal: unable to access 'http://admin:NDA5NzQxOTA4MDkzOr3yF/GiJzn8sofBCW2iCKdc0qTe@192.168.21.97:7990/scm/test/devops.git/': Port number ended with 'N'
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
