### PR TITLE
fix(workflow): modify stage template select options key & alias

### DIFF
--- a/web/src/components/workflow/component/stage/AddStage.js
+++ b/web/src/components/workflow/component/stage/AddStage.js
@@ -110,21 +110,15 @@ class AddStage extends React.Component {
       >
         {templates.map(o => {
           const name = _.get(o, 'metadata.name');
-          const alias = _.get(o, [
-            'metadata',
-            'annotations',
-            'cyclone.dev/alias',
-          ]);
           const namespace = _.get(o, 'metadata.namespace', '');
           const key = namespace ? `${namespace}-${name}` : name;
-          const templateAlias = namespace ? `${namespace}-${alias}` : alias;
           return (
             <Option value={name} key={key}>
               {_.get(o, ['metadata', 'labels', 'cyclone.dev/builtin']) ===
               'true'
                 ? intl.get(`template.kinds.${name.replace('-template', '')}`) ||
-                  key
-                : templateAlias}
+                  name
+                : name}
             </Option>
           );
         })}

--- a/web/src/components/workflow/component/stage/AddStage.js
+++ b/web/src/components/workflow/component/stage/AddStage.js
@@ -110,12 +110,21 @@ class AddStage extends React.Component {
       >
         {templates.map(o => {
           const name = _.get(o, 'metadata.name');
+          const alias = _.get(o, [
+            'metadata',
+            'annotations',
+            'cyclone.dev/alias',
+          ]);
+          const namespace = _.get(o, 'metadata.namespace', '');
+          const key = namespace ? `${namespace}-${name}` : name;
+          const templateAlias = namespace ? `${namespace}-${alias}` : alias;
           return (
-            <Option value={name} key={name}>
+            <Option value={name} key={key}>
               {_.get(o, ['metadata', 'labels', 'cyclone.dev/builtin']) ===
               'true'
-                ? intl.get(`template.kinds.${name.replace('-template', '')}`)
-                : _.get(o, ['metadata', 'annotations', 'cyclone.dev/alias'])}
+                ? intl.get(`template.kinds.${name.replace('-template', '')}`) ||
+                  key
+                : templateAlias}
             </Option>
           );
         })}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

replace stage template select options key & alias with unique key which is composed by <namespace>-<templatename>
![image](https://user-images.githubusercontent.com/3294535/58607648-02e84e80-82d3-11e9-825b-019391bef6d2.png)


**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
