### PR TITLE
fix: display list in descending order of creation

### DIFF
--- a/web/src/components/integration/component/List.js
+++ b/web/src/components/integration/component/List.js
@@ -14,7 +14,7 @@ class List extends React.Component {
   };
   state = { visible: false };
   componentDidMount() {
-    this.props.integration.getIntegrationList();
+    this.props.integration.getIntegrationList({ sort: true, ascending: false });
   }
   addDataSource = () => {
     this.props.history.push('/integration/add');

--- a/web/src/components/project/component/detail/index.js
+++ b/web/src/components/project/component/detail/index.js
@@ -28,7 +28,10 @@ class ProjectDetail extends React.Component {
       },
     } = this.props;
     this.props.project.getProject(projectName);
-    this.props.workflow.listWorklow(projectName);
+    this.props.workflow.listWorklow(projectName, {
+      sort: true,
+      ascending: false,
+    });
   }
   render() {
     const {

--- a/web/src/components/workflow/component/detail/WorkflowRuns.js
+++ b/web/src/components/workflow/component/detail/WorkflowRuns.js
@@ -26,7 +26,10 @@ class WorkflowRuns extends React.Component {
       projectName,
       workflowName,
     } = this.props;
-    listWorkflowRuns(projectName, workflowName);
+    listWorkflowRuns(projectName, workflowName, {
+      sort: true,
+      ascending: false,
+    });
   }
 
   removeRunRecord = name => {
@@ -52,7 +55,11 @@ class WorkflowRuns extends React.Component {
       projectName,
       workflowName,
     } = this.props;
-    listWorkflowRuns(projectName, workflowName, { filter: `name=${val}` });
+    listWorkflowRuns(projectName, workflowName, {
+      filter: `name=${val}`,
+      sort: true,
+      ascending: false,
+    });
   };
 
   render() {

--- a/web/src/components/workflow/component/list/ListLayout.js
+++ b/web/src/components/workflow/component/list/ListLayout.js
@@ -29,10 +29,13 @@ class List extends React.Component {
       history: { location },
     } = this.props;
     const query = qs.parse(location.search);
-    this.props.project.listProjects({}, list => {
+    this.props.project.listProjects({ sort: true, ascending: false }, list => {
       const firstProject =
         query.project || _.get(list, 'items.[0].metadata.name');
-      this.props.workflow.listWorklow(firstProject);
+      this.props.workflow.listWorklow(firstProject, {
+        sort: true,
+        ascending: false,
+      });
       this.props.history.replace(`/workflow?project=${firstProject}`);
     });
   }
@@ -41,7 +44,7 @@ class List extends React.Component {
     const {
       workflow: { listWorklow },
     } = this.props;
-    listWorklow(key);
+    listWorklow(key, { sort: true, ascending: false });
     this.props.history.replace(`/workflow?project=${key}`);
   };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Order of wfr

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #1082 

Reference to #

**Special notes for your reviewer**:

/cc @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
