### PR TITLE
refactor: use mkdir to acquire lock in git resolver

### DIFF
--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -57,12 +57,12 @@ if [ ! -z ${SCM_REPO} ]; then
     SCM_URL=${SCM_URL%/}/${SCM_REPO}.git
 fi
 
-# Lock file for the WorkflowRun.
+# Lock folder for the WorkflowRun.
 PULLING_LOCK=$WORKDIR/${WORKFLOWRUN_NAME}-pulling.lock
 
 releaseLock() {
-    if [ -f /tmp/pulling.lock ]; then
-        echo "Remove the created lock file"
+    if [ -d "$PULLING_LOCK" ]; then
+        echo "Remove the created lock folder"
         rm -rf $PULLING_LOCK
     fi
 }
@@ -115,24 +115,21 @@ wrapPull() {
         echo "Found data, wait it to be ready..."
 
         # If there already be data, then we just wait the data to be ready
-        # by checking the lock file. If the lock file exists, it means other
+        # by checking the lock folder. If the lock folder exists, it means other
         # stage is pulling the data.
-        while [ -f $PULLING_LOCK ]
+        while [ -d $PULLING_LOCK ]
         do
             sleep 3
         done
     else
         echo "Trying to acquire lock and pull resource"
-        # If flock command return 0, it means lock is acquired and can pull resources,
-        # otherwise lock is acquired by others and we should wait.
-        result=$(flock -xn $PULLING_LOCK -c "echo ok; touch /tmp/pulling.lock" || echo fail)
-        if [ $result == "ok" ]; then
+        failed=$(mkdir $PULLING_LOCK > /dev/null 2>&1 || echo fail)
+        if [[ $failed != "fail" ]]; then
             echo "Got the lock, start to pulling..."
             pull
         else
-            # If failed to get the lock, should wait others to finish the pulling by
-            # checking the lock file.
-            while [ -f $PULLING_LOCK ]
+            echo "Failed to get the lock, wait others to finish pulling..."
+            while [ -d $PULLING_LOCK ]
             do
                 sleep 3
             done


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

flock depends on pvc type and image os, for example, with NFS, it will fail on some old linux kernel version.

Switch to a simpler way for the lock, by using mkdir.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
