### PR TITLE
fix: resources not freed immediately after stage finished

### DIFF
--- a/pkg/common/values/nowtime_test.go
+++ b/pkg/common/values/nowtime_test.go
@@ -45,6 +45,10 @@ func TestNowTimeValue(t *testing.T) {
 			"aaaaa",
 			"aaaaa",
 		},
+		{
+			"$(timenow:20060102150405)",
+			"20190524111013",
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -1,10 +1,13 @@
 package retry
 
 import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// OnError executes the provided function repeatedly, retrying if the server returns a error.
+// OnError executes the provided function repeatedly, retrying if the server returns an error.
 func OnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
@@ -19,6 +22,30 @@ func OnError(backoff wait.Backoff, fn func() error) error {
 	})
 	if err == wait.ErrWaitTimeout {
 		err = lastErr
+	}
+	return err
+}
+
+// OnExceededQuota executes the provided function repeatedly, retrying if the server returns an exceeded quota error.
+func OnExceededQuota(backoff wait.Backoff, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.IsForbidden(err):
+			if strings.Contains(err.Error(), "exceeded quota:") {
+				lastConflictErr = err
+				return false, nil
+			}
+			return false, err
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
 	}
 	return err
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -28,7 +28,7 @@ func OnError(backoff wait.Backoff, fn func() error) error {
 
 // OnExceededQuota executes the provided function repeatedly, retrying if the server returns an exceeded quota error.
 func OnExceededQuota(backoff wait.Backoff, fn func() error) error {
-	var lastConflictErr error
+	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		err := fn()
 		switch {
@@ -36,7 +36,7 @@ func OnExceededQuota(backoff wait.Backoff, fn func() error) error {
 			return true, nil
 		case errors.IsForbidden(err):
 			if strings.Contains(err.Error(), "exceeded quota:") {
-				lastConflictErr = err
+				lastErr = err
 				return false, nil
 			}
 			return false, err
@@ -45,7 +45,7 @@ func OnExceededQuota(backoff wait.Backoff, fn func() error) error {
 		}
 	})
 	if err == wait.ErrWaitTimeout {
-		err = lastConflictErr
+		err = lastErr
 	}
 	return err
 }

--- a/pkg/workflow/controller/config.go
+++ b/pkg/workflow/controller/config.go
@@ -48,9 +48,6 @@ type WorkflowControllerConfig struct {
 	NotificationURL string `json:"notification_url"`
 	// DindSettings is settings for Docker in Docker
 	DindSettings DindSettings `json:"dind"`
-
-	// RetrySettins is settings for retry mechanism.
-	RetrySettings RetrySettings `json:"retry"`
 }
 
 // LoggingConfig configures logging
@@ -95,15 +92,6 @@ type DindSettings struct {
 	InsecureRegistries []string `json:"insecure_registries"`
 }
 
-// RetrySettings is settings for controller retry mechanism.
-// For example, count: 6, period: 10 defines try to do something every 10 seconds and do it 6 times.
-type RetrySettings struct {
-	// Count is the max retry times.
-	Count int `json:"count"`
-	// Period is the retry mechanism interval time, unit seconds.
-	Period int `json:"period"`
-}
-
 // Config is Workflow Controller config instance
 var Config WorkflowControllerConfig
 
@@ -123,8 +111,6 @@ func LoadConfig(cm *corev1.ConfigMap) error {
 		return fmt.Errorf("validate config failed")
 	}
 
-	modify(&Config)
-
 	InitLogger(&Config.Logging)
 	return nil
 }
@@ -136,17 +122,6 @@ func validate(config *WorkflowControllerConfig) bool {
 	}
 
 	return true
-}
-
-// modify gives default values if it is empty.
-func modify(config *WorkflowControllerConfig) {
-	if config.RetrySettings.Count == 0 {
-		config.RetrySettings.Count = 3
-	}
-
-	if config.RetrySettings.Period == 0 {
-		config.RetrySettings.Period = 5
-	}
 }
 
 // ImagePullPolicy determines image pull policy based on environment variable DEVELOP_MODE

--- a/pkg/workflow/controller/handlers/pod/operation.go
+++ b/pkg/workflow/controller/handlers/pod/operation.go
@@ -217,13 +217,12 @@ func (p *Operator) DetermineStatus(wfrOperator workflowrun.Operator) {
 	}
 
 	// The workload and coordinator containers have all been finished, but maybe some others are still Running,
-	// Delete the pod and release cpu/memory resources after gc delay seconds since it is not necessary.
-	time.AfterFunc(time.Second*controller.Config.GC.DelaySeconds, func() {
+	// Delete the pod and release cpu/memory resources if gc delay seconds is 0.
+	if controller.Config.GC.DelaySeconds == 0 {
 		if err := p.clusterClient.CoreV1().Pods(p.pod.Namespace).Delete(p.pod.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 			log.WithField("ns", p.pod.Namespace).WithField("pod", p.pod.Name).Warn("Delete pod error: ", err)
 		} else {
 			log.WithField("ns", p.pod.Namespace).WithField("pod", p.pod.Name).Info("Pod deleted")
 		}
-	})
-
+	}
 }

--- a/pkg/workflow/controller/handlers/pod/operation.go
+++ b/pkg/workflow/controller/handlers/pod/operation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
+	"github.com/caicloud/cyclone/pkg/workflow/controller"
 	"github.com/caicloud/cyclone/pkg/workflow/workflowrun"
 )
 
@@ -214,4 +215,15 @@ func (p *Operator) DetermineStatus(wfrOperator workflowrun.Operator) {
 			Message:            "Coordinator completed",
 		})
 	}
+
+	// The workload and coordinator containers have all been finished, but maybe some others are still Running,
+	// Delete the pod and release cpu/memory resources after gc delay seconds since it is not necessary.
+	time.AfterFunc(time.Second*controller.Config.GC.DelaySeconds, func() {
+		if err := p.clusterClient.CoreV1().Pods(p.pod.Namespace).Delete(p.pod.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			log.WithField("ns", p.pod.Namespace).WithField("pod", p.pod.Name).Warn("Delete pod error: ", err)
+		} else {
+			log.WithField("ns", p.pod.Namespace).WithField("pod", p.pod.Name).Info("Pod deleted")
+		}
+	})
+
 }

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -410,7 +410,7 @@ func (o *operator) Reconcile() error {
 // - 'lastTry' indicates whether this is the last try to perform GC on this WorkflowRun object,
 // if set to true, the WorkflowRun would be marked as cleaned regardless whether the GC succeeded or not.
 // - 'wfrDeletion' indicates whether the GC is performed because of WorkflowRun deleted. In this case,
-// GC would performed silently, without event recorded, without status update.
+// GC would performed silently, without event recording and status updating.
 func (o *operator) GC(lastTry, wfrDeletion bool) error {
 	// For each pod created, delete it.
 	for stg, status := range o.wfr.Status.Stages {

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -410,7 +410,7 @@ func (o *operator) Reconcile() error {
 // - 'lastTry' indicates whether this is the last try to perform GC on this WorkflowRun object,
 // if set to true, the WorkflowRun would be marked as cleaned regardless whether the GC succeeded or not.
 // - 'wfrDeletion' indicates whether the GC is performed because of WorkflowRun deleted. In this case,
-// GC would performed silently, without event recorded, withoug status update.
+// GC would performed silently, without event recorded, without status update.
 func (o *operator) GC(lastTry, wfrDeletion bool) error {
 	// For each pod created, delete it.
 	for stg, status := range o.wfr.Status.Stages {
@@ -450,7 +450,7 @@ func (o *operator) GC(lastTry, wfrDeletion bool) error {
 		}
 	}
 
-	// Get exeuction context of the WorkflowRun, namespace and PVC are defined in the context.
+	// Get execution context of the WorkflowRun, namespace and PVC are defined in the context.
 	executionContext := GetExecutionContext(o.wfr)
 
 	// Create a gc pod to clean data on PV if PVC is configured.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

- delete pod immediately after stage finished
- create pod retry on exceeded quota

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
