### PR TITLE
[release-1.0] fix: resources not freed immediately after stage finished

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -1,10 +1,13 @@
 package retry
 
 import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// OnError executes the provided function repeatedly, retrying if the server returns a error.
+// OnError executes the provided function repeatedly, retrying if the server returns an error.
 func OnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
@@ -15,6 +18,30 @@ func OnError(backoff wait.Backoff, fn func() error) error {
 		default:
 			lastErr = err
 			return false, nil
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// OnExceededQuota executes the provided function repeatedly, retrying if the server returns an exceeded quota error.
+func OnExceededQuota(backoff wait.Backoff, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.IsForbidden(err):
+			if strings.Contains(err.Error(), "exceeded quota:") {
+				lastErr = err
+				return false, nil
+			}
+			return false, err
+		default:
+			return false, err
 		}
 	})
 	if err == wait.ErrWaitTimeout {

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -406,7 +406,7 @@ func (o *operator) Reconcile() error {
 // - 'lastTry' indicates whether this is the last try to perform GC on this WorkflowRun object,
 // if set to true, the WorkflowRun would be marked as cleaned regardless whether the GC succeeded or not.
 // - 'wfrDeletion' indicates whether the GC is performed because of WorkflowRun deleted. In this case,
-// GC would performed silently, without event recorded, withoug status update.
+// GC would performed silently, without event recording and status updating.
 func (o *operator) GC(lastTry, wfrDeletion bool) error {
 	// For each pod created, delete it.
 	for stg, status := range o.wfr.Status.Stages {
@@ -446,7 +446,7 @@ func (o *operator) GC(lastTry, wfrDeletion bool) error {
 		}
 	}
 
-	// Get exeuction context of the WorkflowRun, namespace and PVC are defined in the context.
+	// Get execution context of the WorkflowRun, namespace and PVC are defined in the context.
 	executionContext := GetExecutionContext(o.wfr)
 
 	// Create a gc pod to clean data on PV if PVC is configured.

--- a/pkg/workflow/workflowrun/workload.go
+++ b/pkg/workflow/workflowrun/workload.go
@@ -7,10 +7,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
+	"github.com/caicloud/cyclone/pkg/util/retry"
 	"github.com/caicloud/cyclone/pkg/workflow/workload/delegation"
 	"github.com/caicloud/cyclone/pkg/workflow/workload/pod"
 )
@@ -75,8 +77,21 @@ func (p *WorkloadProcessor) processPod() error {
 	}
 	log.WithField("stg", p.stg.Name).Debug("Pod manifest created")
 
-	// Create the generated pod.
-	po, err = p.clusterClient.CoreV1().Pods(pod.GetExecutionContext(p.wfr).Namespace).Create(po)
+	// Create the generated pod with retry on exceeded quota.
+	// Here is a litter tricky. Cyclone will delete stage related pod to release cpu/memory resource when stage have
+	// been finished, but pod deletion needs some time, so retry on exceeded quota gives the time to waiting previous
+	// stage pod deletion.
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 5 * time.Second,
+		Factor:   1.5,
+		Jitter:   0.1,
+	}
+	origin := po.DeepCopy()
+	err = retry.OnExceededQuota(backoff, func() error {
+		po, err = p.clusterClient.CoreV1().Pods(pod.GetExecutionContext(p.wfr).Namespace).Create(origin)
+		return err
+	})
 	if err != nil {
 		log.WithField("wfr", p.wfr.Name).WithField("stg", p.stg.Name).Error("Create pod for stage error: ", err)
 		p.wfrOper.GetRecorder().Eventf(p.wfr, corev1.EventTypeWarning, "StagePodCreated", "Create pod for stage '%s' error: %v", p.stg.Name, err)


### PR DESCRIPTION
* fix: resources not freed immediately after stage finished

* fix: remove retry config

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
