### PR TITLE
chore: disable PVC watcher

### DIFF
--- a/pkg/server/biz/integration/cluster/cluster.go
+++ b/pkg/server/biz/integration/cluster/cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/caicloud/cyclone/pkg/server/biz/integration"
 	"github.com/caicloud/cyclone/pkg/server/biz/pvc"
 	"github.com/caicloud/cyclone/pkg/server/biz/tenant"
-	"github.com/caicloud/cyclone/pkg/server/biz/usage"
 	svrcommon "github.com/caicloud/cyclone/pkg/server/common"
 	"github.com/caicloud/cyclone/pkg/server/config"
 	"github.com/caicloud/cyclone/pkg/util/cerr"
@@ -137,12 +136,12 @@ func Close(client clientset.Interface, in *api.Integration, tenant string) (err 
 	}()
 	cluster := in.Spec.Cluster
 
-	// new cluster clientset
-	clusterClient, err := common.NewClusterClient(&cluster.Credential, cluster.IsControlCluster)
-	if err != nil {
-		log.Errorf("new cluster client error %v", err)
-		return
-	}
+	//// new cluster clientset
+	//clusterClient, err := common.NewClusterClient(&cluster.Credential, cluster.IsControlCluster)
+	//if err != nil {
+	//	log.Errorf("new cluster client error %v", err)
+	//	return
+	//}
 
 	// delete namespace which is created by cyclone
 	if cluster.Namespace == svrcommon.TenantNamespace(tenant) {
@@ -176,10 +175,10 @@ func Close(client clientset.Interface, in *api.Integration, tenant string) (err 
 	}
 
 	// Delete the PVC watcher deployment.
-	err = usage.DeletePVCUsageWatcher(clusterClient, cluster.Namespace)
-	if err != nil {
-		log.Warningf("Delete PVC watcher '%s' error: %v", usage.PVCWatcherName, err)
-	}
+	//err = usage.DeletePVCUsageWatcher(clusterClient, cluster.Namespace)
+	//if err != nil {
+	//	log.Warningf("Delete PVC watcher '%s' error: %v", usage.PVCWatcherName, err)
+	//}
 
 	// delete pvc which is created by cyclone
 	if cluster.PVC == svrcommon.TenantPVC(tenant) {

--- a/pkg/server/biz/pvc/pvc.go
+++ b/pkg/server/biz/pvc/pvc.go
@@ -11,8 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
-	"github.com/caicloud/cyclone/pkg/server/biz/usage"
 	"github.com/caicloud/cyclone/pkg/server/common"
 	"github.com/caicloud/cyclone/pkg/util/retry"
 )
@@ -59,13 +57,14 @@ func CreatePVC(tenantName, storageClass, size string, namespace string, client *
 	}
 
 	// Launch PVC usage watcher to watch the usage of PVC.
-	err = usage.LaunchPVCUsageWatcher(client, tenantName, v1alpha1.ExecutionContext{
-		Namespace: nsname,
-		PVC:       pvcName,
-	})
-	if err != nil {
-		log.Warningf("Launch PVC usage watcher for %s/%s error: %v", nsname, pvcName, err)
-	}
+	//err = usage.LaunchPVCUsageWatcher(client, tenantName, v1alpha1.ExecutionContext{
+	//	Namespace: nsname,
+	//	PVC:       pvcName,
+	//})
+	//if err != nil {
+	//	log.Warningf("Launch PVC usage watcher for %s/%s error: %v", nsname, pvcName, err)
+	//}
+
 	return nil
 }
 
@@ -77,13 +76,13 @@ func DeletePVC(tenantName, namespace string, client *kubernetes.Clientset) error
 		nsname = namespace
 	}
 
-	err := usage.DeletePVCUsageWatcher(client, nsname)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Errorf("delete pvc usage watcher in namespace %s failed %s", nsname, err)
-		return err
-	}
+	//err := usage.DeletePVCUsageWatcher(client, nsname)
+	//if err != nil && !errors.IsNotFound(err) {
+	//	log.Errorf("delete pvc usage watcher in namespace %s failed %s", nsname, err)
+	//	return err
+	//}
 
-	err = client.CoreV1().PersistentVolumeClaims(nsname).Delete(pvcName, &meta_v1.DeleteOptions{})
+	err := client.CoreV1().PersistentVolumeClaims(nsname).Delete(pvcName, &meta_v1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		log.Errorf("delete persistent volume claim %s error %v", pvcName, err)
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

PVC usage is not used yet, and the implementation for the moments have severe performance problems.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
