### PR TITLE
fix: workflow run status check logic

### DIFF
--- a/pkg/workflow/controller/handlers/pod/operation.go
+++ b/pkg/workflow/controller/handlers/pod/operation.go
@@ -176,6 +176,7 @@ func (p *Operator) DetermineStatus(wfrOperator workflowrun.Operator) {
 
 	// Check coordinator container's status, if it's terminated, we regard the pod completed.
 	var terminatedCoordinatorState *corev1.ContainerStateTerminated
+	var coordinatorReady = false
 	for _, containerStatus := range p.pod.Status.ContainerStatuses {
 		if containerStatus.Name == common.CoordinatorSidecarName {
 			if containerStatus.State.Terminated == nil {
@@ -184,26 +185,15 @@ func (p *Operator) DetermineStatus(wfrOperator workflowrun.Operator) {
 			}
 
 			terminatedCoordinatorState = containerStatus.State.Terminated
-
+			coordinatorReady = containerStatus.Ready
 			// There is only one coordinator container in each pod.
 			break
 		}
 	}
 
 	// Now the workload containers and coordinator container have all been finished. We then:
-	// - Update the stage status in WorkflowRun based on coordinator's exit code.
-	if terminatedCoordinatorState.ExitCode != 0 {
-		log.WithField("wfr", wfrOperator.GetWorkflowRun().Name).
-			WithField("stg", p.stage).
-			WithField("status", v1alpha1.StatusFailed).
-			Info("To update stage status")
-		wfrOperator.UpdateStageStatus(p.stage, &v1alpha1.Status{
-			Phase:              v1alpha1.StatusFailed,
-			LastTransitionTime: metav1.Time{Time: time.Now()},
-			Reason:             terminatedCoordinatorState.Reason,
-			Message:            terminatedCoordinatorState.Message,
-		})
-	} else {
+	// - Update the stage status in WorkflowRun based on coordinator's exit code and readiness condition.
+	if terminatedCoordinatorState.ExitCode == 0 && coordinatorReady {
 		log.WithField("wfr", wfrOperator.GetWorkflowRun().Name).
 			WithField("stg", p.stage).
 			WithField("status", v1alpha1.StatusSucceeded).
@@ -213,6 +203,17 @@ func (p *Operator) DetermineStatus(wfrOperator workflowrun.Operator) {
 			LastTransitionTime: metav1.Time{Time: time.Now()},
 			Reason:             "CoordinatorCompleted",
 			Message:            "Coordinator completed",
+		})
+	} else {
+		log.WithField("wfr", wfrOperator.GetWorkflowRun().Name).
+			WithField("stg", p.stage).
+			WithField("status", v1alpha1.StatusFailed).
+			Info("To update stage status")
+		wfrOperator.UpdateStageStatus(p.stage, &v1alpha1.Status{
+			Phase:              v1alpha1.StatusFailed,
+			LastTransitionTime: metav1.Time{Time: time.Now()},
+			Reason:             terminatedCoordinatorState.Reason,
+			Message:            terminatedCoordinatorState.Message,
 		})
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Fix workflow run status check logic, it should be `Failed` when the coordinator container not ready.
![image](https://user-images.githubusercontent.com/36154065/62407406-b975f180-b5ea-11e9-88fa-ee4a6b74ec79.png)



**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
