### PR TITLE
fix: bitbucket pr webhook problem

### DIFF
--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -26,10 +26,10 @@ USAGE=$(cat <<-END
        repo can be given here.
      - SCM_REVISION [Required] Revision of the source code. It has two different
        format. a) Single revision, such as branch 'master', tag 'v1.0'; b). Composite
-       such as pull requests, 'develop:master' indicates merge 'develop' branch to
-       'master'. For GitHub, pull requests can use the single revision form, such as
-       'refs/pull/1/merge', but for Gitlab, composite revision is necessary, such as
-       'refs/merge-requests/1/head:master'.
+       such as pull requests, 'develop:master' indicates merge 'develop' branch to 'master'.
+       For GitHub and Bitbucket, pull requests can use the single revision form, such as
+       'refs/pull/1/merge' for GitHub and 'refs/pull-requests/1/merge' for Bitbucket; but for
+       Gitlab, composite revision is necessary, such as 'refs/merge-requests/1/head:master'.
      - SCM_AUTH [Optional] For public repository, no need provide auth, but for
        private repository, this should be provided. Auth here supports 2 different formats:
        a. <user>:<password>

--- a/pkg/server/biz/scm/bitbucket/server/webhooks.go
+++ b/pkg/server/biz/scm/bitbucket/server/webhooks.go
@@ -20,7 +20,7 @@ const (
 
 	releaseRefPrefix = "refs/heads/release/"
 	// pullRefTemplate represents reference template for pull request.
-	pullRefTemplate = "refs/pull-requests/%d/from"
+	pullRefTemplate = "refs/pull-requests/%d/merge"
 )
 
 var supportEventMap = map[string]bool{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Difference of refs/pull-requests/id/merge and refs/pull-requests/id/from: https://community.atlassian.com/t5/Bitbucket-questions/Difference-of-refs-pull-requests-lt-ID-gt-merge-and-refs-pull/qaq-p/772142

https://blog.developer.atlassian.com/a-better-pull-request/

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
