### PR TITLE
fix: defer exit to collect init containers' logs

### DIFF
--- a/build/toolbox/Dockerfile
+++ b/build/toolbox/Dockerfile
@@ -4,4 +4,6 @@ LABEL maintainer="zhujian@caicloud.io"
 
 WORKDIR /usr/bin/cyclone-toolbox
 
+RUN apk add --no-cache coreutils
+
 COPY ./build/toolbox/resolver-runner.sh ./bin/toolbox/fstream /usr/bin/cyclone-toolbox/

--- a/build/toolbox/resolver-runner.sh
+++ b/build/toolbox/resolver-runner.sh
@@ -4,10 +4,16 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+function finish {
+  echo "sleep 1 second to collect logs"
+  sleep 1
+}
+trap finish EXIT
+
 if [ ! -z ${LOG_COLLECTOR_URL} ]; then
   touch /tmp/log.txt
   /usr/bin/cyclone-toolbox/fstream -f /tmp/log.txt -s ${LOG_COLLECTOR_URL} &
-  /entrypoint.sh "$@" 2>&1 | tee /tmp/log.txt
+  stdbuf -o0 -e0 /entrypoint.sh "$@" 2>&1 | stdbuf -o0 -e0 -i0 tee /tmp/log.txt
 else
   /entrypoint.sh "$@"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

defer exit to collect init containers' logs

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
