### PR TITLE
fix: add target branch for list pull requests api

### DIFF
--- a/pkg/server/biz/scm/gitlab/gitlabv3.go
+++ b/pkg/server/biz/scm/gitlab/gitlabv3.go
@@ -156,10 +156,11 @@ func (g *V3) ListPullRequests(repo, state string) ([]scm.PullRequest, error) {
 
 		for _, p := range prs {
 			allPRs = append(allPRs, scm.PullRequest{
-				ID:          p.IID,
-				Title:       p.Title,
-				Description: p.Description,
-				State:       p.State,
+				ID:           p.IID,
+				Title:        p.Title,
+				Description:  p.Description,
+				State:        p.State,
+				TargetBranch: p.TargetBranch,
 			})
 		}
 		if resp.NextPage == 0 {

--- a/pkg/server/biz/scm/gitlab/gitlabv4.go
+++ b/pkg/server/biz/scm/gitlab/gitlabv4.go
@@ -172,10 +172,11 @@ func (g *V4) ListPullRequests(repo, state string) ([]scm.PullRequest, error) {
 
 		for _, p := range prs {
 			allPRs = append(allPRs, scm.PullRequest{
-				ID:          p.IID,
-				Title:       p.Title,
-				Description: p.Description,
-				State:       p.State,
+				ID:           p.IID,
+				Title:        p.Title,
+				Description:  p.Description,
+				State:        p.State,
+				TargetBranch: p.TargetBranch,
 			})
 		}
 		if resp.NextPage == 0 {

--- a/pkg/server/biz/scm/scm.go
+++ b/pkg/server/biz/scm/scm.go
@@ -176,4 +176,6 @@ type PullRequest struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	State       string `json:"state"`
+	// TargetBranch used for GitLab to indicate to which branch the merge-request should merge.
+	TargetBranch string `json:"targetBranch"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

When a pipeline is triggered by GitLab merge-requests, the [`SCM_REVISION`](cyclone-server-server-v1-0-864b879456-ssw5v) should in the format of `refs/merge-requests/{id}/head:{target-branch}` so add target branch for GitLab while list merge requests.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
