### PR TITLE
fix: image tag wrong when workflow triggered by bitbucket release

### DIFF
--- a/pkg/server/handler/v1alpha1/webhook.go
+++ b/pkg/server/handler/v1alpha1/webhook.go
@@ -119,14 +119,14 @@ func createWorkflowRun(tenant string, wft v1alpha1.WorkflowTrigger, data *scm.Ev
 		if st.TagRelease.Enabled {
 			trigger = true
 			tag = data.Ref
-			splitTags := strings.Split(data.Ref, "/")
-			if len(splitTags) == 3 {
-				tag = splitTags[2]
+			// If tag contains "/", trim it.
+			if index := strings.LastIndex(tag, "/"); index >= 0 && len(tag) > index+1 {
+				tag = tag[index+1:]
 			}
 		}
 	case scm.PushEventType:
 		trimmedBranch := data.Branch
-		if index := strings.LastIndex(data.Branch, "/"); index >= 0 {
+		if index := strings.LastIndex(trimmedBranch, "/"); index >= 0 && len(trimmedBranch) > index+1 {
 			trimmedBranch = trimmedBranch[index+1:]
 		}
 		for _, branch := range st.Push.Branches {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Image tag wrong when workflow triggered by bitbucket release.
Tag is in the format of `refs/heads/release/{name}`, we need to change it to `{name}`

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
