### PR TITLE
fix: GitHub tag trigger problem

### DIFF
--- a/pkg/server/biz/scm/github/github.go
+++ b/pkg/server/biz/scm/github/github.go
@@ -548,6 +548,7 @@ func convertToGithubEvents(events []scm.EventType) []string {
 			ge = append(ge, "push")
 		case scm.TagReleaseEventType:
 			ge = append(ge, "release")
+			ge = append(ge, "create")
 		default:
 			log.Errorf("The event type %s is not supported, will be ignored", e)
 		}
@@ -587,6 +588,17 @@ func ParseEvent(scmCfg *v1alpha1.SCMSource, request *http.Request) *scm.EventDat
 	}
 
 	switch event := event.(type) {
+	case *github.CreateEvent:
+		refType := *event.RefType
+		if refType != "tag" {
+			log.Warningf("Skip unsupported ref type %s of Github create event, only support create tag event.", refType)
+			return nil
+		}
+		return &scm.EventData{
+			Type: scm.TagReleaseEventType,
+			Repo: *event.Repo.FullName,
+			Ref:  fmt.Sprintf(tagRefTemplate, *event.Ref),
+		}
 	case *github.ReleaseEvent:
 		// Only handle when the tag is created.
 		// When you create a new release in your GitHub, GitHub will send

--- a/pkg/server/biz/scm/github/github.go
+++ b/pkg/server/biz/scm/github/github.go
@@ -547,7 +547,6 @@ func convertToGithubEvents(events []scm.EventType) []string {
 		case scm.PushEventType:
 			ge = append(ge, "push")
 		case scm.TagReleaseEventType:
-			ge = append(ge, "release")
 			ge = append(ge, "create")
 		default:
 			log.Errorf("The event type %s is not supported, will be ignored", e)
@@ -598,23 +597,6 @@ func ParseEvent(scmCfg *v1alpha1.SCMSource, request *http.Request) *scm.EventDat
 			Type: scm.TagReleaseEventType,
 			Repo: *event.Repo.FullName,
 			Ref:  fmt.Sprintf(tagRefTemplate, *event.Ref),
-		}
-	case *github.ReleaseEvent:
-		// Only handle when the tag is created.
-		// When you create a new release in your GitHub, GitHub will send
-		// two release X-GitHub-Event(and one push X-GitHub-Event, not discussed here):
-		// - one action is 'created'
-		// - the other one is 'published'
-		// So we only process the 'created' one, otherwise, one release will trigger a workflow twice.
-		action := *event.Action
-		if action != "created" {
-			log.Warningf("Skip unsupported action %s of Github release event, only support created action.", action)
-			return nil
-		}
-		return &scm.EventData{
-			Type: scm.TagReleaseEventType,
-			Repo: *event.Repo.FullName,
-			Ref:  fmt.Sprintf(tagRefTemplate, *event.Release.TagName),
 		}
 	case *github.PullRequestEvent:
 		// Only handle when the pull request are created.

--- a/pkg/server/handler/v1alpha1/webhook.go
+++ b/pkg/server/handler/v1alpha1/webhook.go
@@ -80,19 +80,79 @@ func HandleWebhook(ctx context.Context, tenant, eventType, integration string) (
 		return newWebhookResponse(err.Error()), err
 	}
 
-	sftName := make([]string, 0)
+	triggeredWfts := make([]string, 0)
 	for _, wft := range wfts.Items {
+		if !needTrigger(wft, data.Type, data.Ref) {
+			continue
+		}
+
 		log.Infof("Trigger workflow trigger %s", wft.Name)
-		sftName = append(sftName, wft.Name)
+		triggeredWfts = append(triggeredWfts, wft.Name)
 		if err = createWorkflowRun(tenant, wft, data); err != nil {
 			log.Errorf("wft %s create workflow run error:%v", wft.Name, err)
 		}
 	}
-	if len(sftName) > 0 {
-		return newWebhookResponse(fmt.Sprintf("%s: %s", succeededMsg, sftName)), nil
+	if len(triggeredWfts) > 0 {
+		return newWebhookResponse(fmt.Sprintf("%s: %s", succeededMsg, triggeredWfts)), nil
 	}
 
 	return newWebhookResponse(ignoredMsg), nil
+}
+
+// needTrigger returns false only when there are workflows in following conditions:
+//   - triggered by the tag release event type, same with the incoming trigger event;
+//   - still Running;
+//   - have same SCM_REVISION with the incoming trigger event.
+// otherwise, returns true.
+func needTrigger(wft v1alpha1.WorkflowTrigger, eventType scm.EventType, revision string) bool {
+	workflowRef := wft.Spec.WorkflowRef
+	workflowRuns, err := handler.K8sClient.CycloneV1alpha1().WorkflowRuns(workflowRef.Namespace).List(metav1.ListOptions{
+		LabelSelector: meta.WorkflowSelector(workflowRef.Name),
+	})
+	if err != nil {
+		return true
+	}
+
+	for _, workflowRun := range workflowRuns.Items {
+		if workflowRun.Annotations == nil {
+			return true
+		}
+
+		if workflowRun.Annotations[meta.AnnotationWorkflowRunTrigger] != string(eventType) {
+			return true
+		}
+
+		if eventType != scm.TagReleaseEventType {
+			return true
+		}
+
+		if getSCMRevision(workflowRun) != revision {
+			return true
+		}
+
+		phase := workflowRun.Status.Overall.Phase
+		if phase == v1alpha1.StatusRunning ||
+			phase == v1alpha1.StatusPending ||
+			phase == v1alpha1.StatusWaiting {
+			log.Infof("Event %s revision %s does not need to trigger a new workflowRun, workflowRun %s is still in Status %s.",
+				eventType, revision, workflowRun.Name, phase)
+			return false
+		}
+	}
+
+	return true
+}
+
+func getSCMRevision(wfr v1alpha1.WorkflowRun) string {
+	// "SCM_REVISION" for all resource configs.
+	for _, resource := range wfr.Spec.Resources {
+		for _, parameter := range resource.Parameters {
+			if parameter.Name == "SCM_REVISION" {
+				return *parameter.Value
+			}
+		}
+	}
+	return ""
 }
 
 func createWorkflowRun(tenant string, wft v1alpha1.WorkflowTrigger, data *scm.EventData) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

The `tag-release` trigger for GitHub webhook has an issue: GitHub `release creation` can trigger workflows, but `tag creation` can not. 
This PR will fix it.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @cd1989 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
