### PR TITLE
fix: close websocket when workflow run running completed

### DIFF
--- a/pkg/util/websocket/websocket.go
+++ b/pkg/util/websocket/websocket.go
@@ -77,7 +77,7 @@ func SendStream(server string, reader io.Reader, close <-chan struct{}) error {
 // Send sends stream from reader by websocket
 func Send(ws *websocket.Conn, reader io.Reader, close <-chan struct{}) error {
 	buf := bufio.NewReader(reader)
-	err := Write(ws, buf)
+	err := Write(ws, buf, close)
 	if err != nil {
 		log.Error("websocket writer error:", err)
 	}
@@ -92,14 +92,31 @@ type ReadBytes interface {
 }
 
 // Write writes message from reader to websocket
-func Write(ws *websocket.Conn, reader ReadBytes) error {
+func Write(ws *websocket.Conn, reader ReadBytes, stopCh <-chan struct{}) error {
 	pingTicker := time.NewTicker(PingPeriod)
 	sendTicker := time.NewTicker(10 * time.Millisecond)
+	exit := make(chan struct{})
 	defer func() {
 		log.Info("close ticket and websocket")
 		pingTicker.Stop()
 		sendTicker.Stop()
 		ws.Close()
+		close(exit)
+	}()
+
+	stop := make(chan struct{})
+	// delay exit to ensure remanent message sending.
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				time.Sleep(5 * time.Second)
+				close(stop)
+				return
+			case <-exit:
+				return
+			}
+		}
 	}()
 
 	for {
@@ -147,6 +164,17 @@ func Write(ws *websocket.Conn, reader ReadBytes) error {
 					return err
 				}
 			}
+		case <-stop:
+			err := ws.SetWriteDeadline(time.Now().Add(WriteWait))
+			if err != nil {
+				log.Warning("set write deadline error:", err)
+			}
+			err = ws.WriteMessage(websocket.CloseMessage, []byte("Message sending complete, TERMINATE"))
+			if err != nil {
+				log.Error("write close message error: ", err)
+				return err
+			}
+			return nil
 		}
 	}
 }

--- a/pkg/util/websocket/websocket.go
+++ b/pkg/util/websocket/websocket.go
@@ -97,7 +97,7 @@ func Write(ws *websocket.Conn, reader ReadBytes, stopCh <-chan struct{}) error {
 	sendTicker := time.NewTicker(10 * time.Millisecond)
 	exit := make(chan struct{})
 	defer func() {
-		log.Info("close ticket and websocket")
+		log.Info("close ticker and websocket")
 		pingTicker.Stop()
 		sendTicker.Stop()
 		ws.Close()
@@ -105,17 +105,15 @@ func Write(ws *websocket.Conn, reader ReadBytes, stopCh <-chan struct{}) error {
 	}()
 
 	stop := make(chan struct{})
-	// delay exit to ensure remanent message sending.
+	// delay exit to ensure remained messages sent.
 	go func() {
-		for {
-			select {
-			case <-stopCh:
-				time.Sleep(5 * time.Second)
-				close(stop)
-				return
-			case <-exit:
-				return
-			}
+		select {
+		case <-stopCh:
+			time.Sleep(30 * time.Second)
+			close(stop)
+			return
+		case <-exit:
+			return
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Close log stream websocket when workflow run running completed

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
