### PR TITLE
[CPS-2.8] fix: eof of stage logs FolderReader

### DIFF
--- a/cmd/workflow/coordinator/main.go
+++ b/cmd/workflow/coordinator/main.go
@@ -68,6 +68,13 @@ func main() {
 	if err != nil {
 		return
 	}
+	defer func() {
+		go func() {
+			if err := c.MarkLogEOF(); err != nil {
+				log.Warn("Mark log EOF error: ", err)
+			}
+		}()
+	}()
 
 	// Wait workload containers completion, so we can notify output resolvers.
 	log.Info("Wait workload containers completion ... ")

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -24,6 +24,9 @@ const (
 	// EnvSystemNamespace is the evn key to indicate which namespace the cyclone system components installed in.
 	// Cyclone built-in resources(such as stage templates) will be stored in the namespace too.
 	EnvSystemNamespace = "SYSTEM_NAMESPACE"
+
+	// FolderEOFFile is a file placed in a folder to indicate content are all ready. It's used in FolderReader.
+	FolderEOFFile = "__eof__"
 )
 
 // GetSystemNamespace ...

--- a/pkg/server/biz/stream/folder.go
+++ b/pkg/server/biz/stream/folder.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caicloud/cyclone/pkg/common"
 	"github.com/caicloud/nirvana/log"
 )
 
@@ -36,6 +38,7 @@ type folderReader struct {
 	filesMap    map[string]struct{}
 	lock        *sync.Mutex
 	watcherStop chan struct{}
+	eofCallback context.CancelFunc
 }
 
 type fileReader struct {
@@ -63,6 +66,12 @@ func (s fileReadersSorter) Len() int {
 // can adjust the container index by fix weights 100, 200 to make the trick.
 // If sort by the weight, result will be: i1, i2, ... main ... csc-o1, csc-o2, ...
 func containerWeight(c string) int {
+	// EOF file of the folder to indicate end of the folder content it should have
+	// the smallest weight.
+	if c == common.FolderEOFFile {
+		return -1000
+	}
+
 	if InputContainerRegex.MatchString(c) {
 		i, _ := strconv.Atoi(strings.TrimPrefix(c, "i"))
 		return -i + 200
@@ -91,7 +100,7 @@ func (s fileReadersSorter) Swap(i, j int) {
 // - folder Path of the folder
 // - prefix Only file names with given prefix would be read
 // - exclusions Exclude given files
-func NewFolderReader(folder string, prefix string, exclusions []string, duration time.Duration) FolderReader {
+func NewFolderReader(folder string, prefix string, exclusions []string, duration time.Duration, eofCallback context.CancelFunc) FolderReader {
 	folderRdr := &folderReader{
 		folder:      folder,
 		prefix:      prefix,
@@ -100,6 +109,7 @@ func NewFolderReader(folder string, prefix string, exclusions []string, duration
 		filesMap:    make(map[string]struct{}),
 		lock:        &sync.Mutex{},
 		watcherStop: make(chan struct{}),
+		eofCallback: eofCallback,
 	}
 
 	folderRdr.watch()
@@ -113,6 +123,15 @@ func NewFolderReader(folder string, prefix string, exclusions []string, duration
 // ReadBytes reads content from each file in the folder
 func (r *folderReader) ReadBytes(delim byte) ([]byte, error) {
 	for _, reader := range r.readers {
+		// Attempt to read EOF file means end of the folder content
+		if strings.Contains(reader.name, common.FolderEOFFile) {
+			if r.eofCallback != nil {
+				r.eofCallback()
+			}
+
+			return nil, io.EOF
+		}
+
 		line, err := reader.reader.ReadBytes(delim)
 
 		// Some non io.EOF error, exit directly
@@ -139,6 +158,14 @@ func (r *folderReader) ReadBytes(delim byte) ([]byte, error) {
 // returns what is available instead of waiting for more.
 func (r *folderReader) Read(p []byte) (int, error) {
 	for _, reader := range r.readers {
+		// Attempt to read EOF file means end of the folder content
+		if strings.Contains(reader.name, common.FolderEOFFile) {
+			if r.eofCallback != nil {
+				r.eofCallback()
+			}
+			return 0, io.EOF
+		}
+
 		n, err := reader.reader.Read(p)
 		if n > 0 {
 			if err == io.EOF {

--- a/pkg/server/biz/stream/folder_test.go
+++ b/pkg/server/biz/stream/folder_test.go
@@ -70,7 +70,7 @@ func TestFolderReader(t *testing.T) {
 	}
 	defer clean()
 
-	reader := NewFolderReader(testDir, "cyclone_", []string{"cyclone_skip"}, 0)
+	reader := NewFolderReader(testDir, "cyclone_", []string{"cyclone_skip"}, 0, nil)
 	defer reader.Close()
 
 	expecteds := []string{

--- a/pkg/util/websocket/websocket.go
+++ b/pkg/util/websocket/websocket.go
@@ -92,7 +92,7 @@ type ReadBytes interface {
 }
 
 // Write writes message from reader to websocket
-func Write(ws *websocket.Conn, reader ReadBytes, stopCh <-chan struct{}) error {
+func Write(ws *websocket.Conn, reader ReadBytes, stop <-chan struct{}) error {
 	pingTicker := time.NewTicker(PingPeriod)
 	sendTicker := time.NewTicker(10 * time.Millisecond)
 	exit := make(chan struct{})
@@ -102,19 +102,6 @@ func Write(ws *websocket.Conn, reader ReadBytes, stopCh <-chan struct{}) error {
 		sendTicker.Stop()
 		ws.Close()
 		close(exit)
-	}()
-
-	stop := make(chan struct{})
-	// delay exit to ensure remained messages sent.
-	go func() {
-		select {
-		case <-stopCh:
-			time.Sleep(30 * time.Second)
-			close(stop)
-			return
-		case <-exit:
-			return
-		}
 	}()
 
 	for {

--- a/pkg/workflow/coordinator/coordinator.go
+++ b/pkg/workflow/coordinator/coordinator.go
@@ -39,6 +39,8 @@ type RuntimeExecutor interface {
 	WaitContainers(state common.ContainerState, selectors ...common.ContainerSelector) error
 	// CollectLog collects container logs to cyclone server.
 	CollectLog(container, wrorkflowrun, stage string) error
+	// MarkLogEOF marks end of stage logs.
+	MarkLogEOF(workflowrun, stage string) error
 	// CopyFromContainer copy a file or directory from container:path to dst.
 	CopyFromContainer(container, path, dst string) error
 	// GetPod get the stage related pod.
@@ -112,6 +114,11 @@ func (co *Coordinator) CollectLogs() error {
 	}
 
 	return nil
+}
+
+// MarkLogEOF marks end of stage logs.
+func (co *Coordinator) MarkLogEOF() error {
+	return co.runtimeExec.MarkLogEOF(co.Wfr.Name, co.Stage.Name)
 }
 
 // WaitRunning waits all containers to start run.

--- a/pkg/workflow/coordinator/cycloneserver/client.go
+++ b/pkg/workflow/coordinator/cycloneserver/client.go
@@ -20,7 +20,7 @@ const (
 
 // Client ...
 type Client interface {
-	PushLogStream(ns, workflowrun, stage, container string, reader io.Reader, close chan struct{}) error
+	PushLogStream(ns, workflowrun, stage, container string, reader io.Reader) error
 }
 
 type client struct {
@@ -42,7 +42,7 @@ func NewClient(cycloneServer string) Client {
 }
 
 // PushLogStream ...
-func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader io.Reader, close chan struct{}) error {
+func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader io.Reader) error {
 	path := fmt.Sprintf(apiPathForLogStream, workflowrun)
 	host := strings.TrimPrefix(c.baseURL, "http://")
 	host = strings.TrimPrefix(host, "https://")
@@ -54,6 +54,5 @@ func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader 
 	}
 
 	log.Infof("Path: %s", requestURL.String())
-	return websocketutil.SendStream(requestURL.String(), reader, close)
-
+	return websocketutil.SendStream(requestURL.String(), reader, make(chan struct{}))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add EOF file to stage logs folder to indicate end of stage logs, so that realtime logs can have a done signal.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @zhujian7 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
