### PR TITLE
fix: execution context of workflow trigger expire when cluster changed

### DIFF
--- a/pkg/server/biz/integration/cluster/trigger.go
+++ b/pkg/server/biz/integration/cluster/trigger.go
@@ -1,0 +1,164 @@
+package cluster
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"github.com/caicloud/nirvana/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	cycloneV1alpha1 "github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	cycloneCommon "github.com/caicloud/cyclone/pkg/common"
+	"github.com/caicloud/cyclone/pkg/server/apis/v1alpha1"
+	"github.com/caicloud/cyclone/pkg/server/common"
+	"github.com/caicloud/cyclone/pkg/server/handler"
+	"github.com/caicloud/cyclone/pkg/util/cerr"
+)
+
+// ReconcileTriggerExecutionContext reconciles execution context for workflow triggers.
+// Update WorkflowTriggers' unavailable execution context (related cluster closed or
+// deleted) with an available one (related cluster opened).
+func ReconcileTriggerExecutionContext(tenant string) error {
+	// List all available worker clusters
+	availableExecutionContexts, err := listAvailableExecutionContext(tenant)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Available execution context: %v", availableExecutionContexts)
+	if len(availableExecutionContexts) == 0 {
+		return cerr.ErrorUnknownInternal.Error(fmt.Sprintf("No execution context available for tenant: %s", tenant))
+	}
+
+	// List all WorkflowTriggers of the tenant
+	workflowTriggers, err := handler.K8sClient.CycloneV1alpha1().WorkflowTriggers(common.TenantNamespace(tenant)).List(metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("List workflowtriggers from k8s for tenant %s with error: %v", tenant, err)
+		return err
+	}
+
+	var goerr error
+	wg := sync.WaitGroup{}
+	for _, workflowTrigger := range workflowTriggers.Items {
+		wg.Add(1)
+
+		go func(wft cycloneV1alpha1.WorkflowTrigger) {
+			defer wg.Done()
+
+			var needUpdate = false
+			if wft.Spec.WorkflowRunSpec.ExecutionContext == nil {
+				needUpdate = true
+			} else if _, ok := availableExecutionContexts[wft.Spec.WorkflowRunSpec.ExecutionContext.Cluster]; !ok {
+				needUpdate = true
+			}
+			if !needUpdate {
+				return
+			}
+
+			executionContext := randExecutionContext(availableExecutionContexts)
+			if executionContext == nil {
+				goerr = fmt.Errorf("get random execution context error")
+				return
+			}
+			log.Infof("WorkflowTrigger %s's execution context need to be updated to cluster %s", wft.Name, executionContext.Cluster)
+
+			newWft := wft.DeepCopy()
+			newWft.Spec.WorkflowRunSpec.ExecutionContext = executionContext
+			_, err := handler.K8sClient.CycloneV1alpha1().WorkflowTriggers(common.TenantNamespace(tenant)).Update(newWft)
+			if err == nil {
+				// Update wft succeeded, return directly.
+				return
+			}
+
+			// Update workflowTrigger failed, start to retry.
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				origin, err := handler.K8sClient.CycloneV1alpha1().WorkflowTriggers(common.TenantNamespace(tenant)).Get(wft.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				newWft := origin.DeepCopy()
+				newWft.Spec.WorkflowRunSpec.ExecutionContext = executionContext
+				_, err = handler.K8sClient.CycloneV1alpha1().WorkflowTriggers(common.TenantNamespace(tenant)).Update(newWft)
+				return err
+			})
+			if err != nil {
+				goerr = cerr.ConvertK8sError(err)
+				return
+			}
+		}(workflowTrigger)
+	}
+
+	wg.Wait()
+	if goerr != nil {
+		return goerr
+	}
+	return nil
+}
+
+func listAvailableExecutionContext(tenant string) (map[string]*cycloneV1alpha1.ExecutionContext, error) {
+	executionContexts := make(map[string]*cycloneV1alpha1.ExecutionContext)
+
+	integrations, err := GetSchedulableClusters(handler.K8sClient, tenant)
+	if err != nil {
+		return executionContexts, err
+	}
+
+	for _, integration := range integrations {
+		cluster := integration.Spec.Cluster
+		if cluster == nil {
+			continue
+		}
+
+		if !cluster.IsWorkerCluster {
+			continue
+		}
+
+		executionContexts[executionContextClusterName(cluster.ClusterName, cluster.IsControlCluster)] =
+			construstExecutionContext(cluster, tenant)
+	}
+
+	return executionContexts, nil
+}
+
+func executionContextClusterName(originClusterName string, isControlCluster bool) string {
+	if isControlCluster {
+		return cycloneCommon.ControlClusterName
+	}
+
+	return originClusterName
+}
+
+func construstExecutionContext(clusterSource *v1alpha1.ClusterSource, tenant string) *cycloneV1alpha1.ExecutionContext {
+	executionContext := &cycloneV1alpha1.ExecutionContext{
+		Cluster:   executionContextClusterName(clusterSource.ClusterName, clusterSource.IsControlCluster),
+		Namespace: clusterSource.Namespace,
+		PVC:       clusterSource.PVC,
+	}
+
+	if executionContext.Namespace == "" {
+		executionContext.Namespace = common.TenantNamespace(tenant)
+	}
+	if executionContext.PVC == "" {
+		executionContext.PVC = common.TenantPVC(tenant)
+	}
+
+	return executionContext
+}
+
+func randExecutionContext(clusters map[string]*cycloneV1alpha1.ExecutionContext) *cycloneV1alpha1.ExecutionContext {
+	if clusters == nil {
+		return nil
+	}
+
+	i := rand.Intn(len(clusters))
+	for k := range clusters {
+		if i == 0 {
+			return clusters[k]
+		}
+		i--
+	}
+
+	return nil
+}

--- a/pkg/server/handler/v1alpha1/integration.go
+++ b/pkg/server/handler/v1alpha1/integration.go
@@ -309,7 +309,13 @@ func OpenCluster(ctx context.Context, tenant, name string) error {
 		return err
 	}
 
-	return updateSecret(ns, integration.GetSecretName(name), in.Spec.Type, secret)
+	err = updateSecret(ns, integration.GetSecretName(name), in.Spec.Type, secret)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Open cluster succeeded, start to reconcile WorkflowTriggers' execution context")
+	return cluster.ReconcileTriggerExecutionContext(tenant)
 }
 
 // CloseCluster closes cluster type integration that used to execute workflow

--- a/pkg/workflow/workflowrun/workload.go
+++ b/pkg/workflow/workflowrun/workload.go
@@ -104,6 +104,7 @@ func (p *WorkloadProcessor) processPod() error {
 		return err
 	}
 
+	log.WithField("wfr", p.wfr.Name).WithField("stg", p.stg.Name).Debug("Create pod for stage succeeded")
 	p.wfrOper.GetRecorder().Eventf(p.wfr, corev1.EventTypeNormal, "StagePodCreated", "Create pod for stage '%s' succeeded", p.stg.Name)
 	p.wfrOper.UpdateStageStatus(p.stg.Name, &v1alpha1.Status{
 		Phase:              v1alpha1.StatusRunning,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

The execution context of workflow triggers expire when the worker cluster of the tenant changed. 
This PR will reconcile the execution context of workflow triggers when a worker cluster is opened.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
