### PR TITLE
feat: record workflow topology to workflow run

### DIFF
--- a/pkg/apis/cyclone/v1alpha1/workflow_run.go
+++ b/pkg/apis/cyclone/v1alpha1/workflow_run.go
@@ -134,6 +134,12 @@ type StageStatus struct {
 	Status Status `json:"status"`
 	// Key-value outputs of this stage
 	Outputs []KeyValue `json:"outputs"`
+	// Stages that this stage depends on.
+	Depends []string `json:"depends"`
+	// Trivial indicates whether this stage is critical in the workflow. If set to true, it means the workflow
+	// can tolerate failure of this stage. In this case, all other stages can continue to execute and the overall
+	// status of the workflow execution can still be succeed.
+	Trivial bool `json:"trivial"`
 }
 
 // StatusPhase represents the phase of stage status or workflowrun status.

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -119,7 +119,7 @@ func (o *operator) GetRecorder() record.EventRecorder {
 	return o.recorder
 }
 
-// InitStagesStatus initializes all missing stages' status to pending.
+// InitStagesStatus initializes all missing stages' status to pending, and record workflow topology at this time to workflowRun status.
 func (o *operator) InitStagesStatus() {
 	if o.wfr.Status.Stages == nil {
 		o.wfr.Status.Stages = make(map[string]*v1alpha1.StageStatus)
@@ -131,6 +131,8 @@ func (o *operator) InitStagesStatus() {
 				Status: v1alpha1.Status{
 					Phase: v1alpha1.StatusPending,
 				},
+				Depends: stg.Depends,
+				Trivial: stg.Trivial,
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

If the topology of a workflow changed, the old workflowRun's running status can not display, So we need to record workflow topology at workflowRun running time to workflowRun status.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @cd1989 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
