### PR TITLE
fix: deleting pod stuck on Terminating status

### DIFF
--- a/pkg/meta/labels.go
+++ b/pkg/meta/labels.go
@@ -84,6 +84,8 @@ func (pk PodKind) String() string {
 const (
 	// PodKindGC represents the pod is used for GC purpose.
 	PodKindGC PodKind = "gc"
+	// PodKindWorkload represents the pod is used to run a stage workload.
+	PodKindWorkload PodKind = "workload"
 )
 
 // ProjectSelector is a selector for cyclone CRD resources which have corresponding project label
@@ -185,6 +187,21 @@ func WorkflowRunSelector() string {
 	}
 
 	return fmt.Sprintf("%s=%s", LabelControllerInstance, instance)
+}
+
+// WorkflowRunPodSelector selects pods that belongs to a WorkflowRun.
+func WorkflowRunPodSelector(wfr string) string {
+	return fmt.Sprintf("%s=%s", LabelWorkflowRunName, wfr)
+}
+
+// WorkloadPodSelector selects pods that used to execute workload.
+func WorkloadPodSelector() string {
+	return fmt.Sprintf("%s=%s", LabelPodKind, PodKindWorkload.String())
+}
+
+// WorkflowRunWorkloadPodSelector selects pods that used to execute a WorkflowRun's workload.
+func WorkflowRunWorkloadPodSelector(wfr string) string {
+	return fmt.Sprintf("%s,%s", WorkflowRunPodSelector(wfr), WorkloadPodSelector())
 }
 
 // LabelExistsSelector returns a label selector to query resources with label key exists.

--- a/pkg/workflow/workload/pod/builder.go
+++ b/pkg/workflow/workload/pod/builder.go
@@ -83,6 +83,7 @@ func (m *Builder) Prepare() error {
 		Labels: map[string]string{
 			meta.LabelWorkflowRunName: m.wfr.Name,
 			meta.LabelPodCreatedBy:    meta.CycloneCreator,
+			meta.LabelPodKind:         meta.PodKindWorkload.String(),
 		},
 		Annotations: map[string]string{
 			meta.AnnotationIstioInject:     meta.AnnotationValueFalse,


### PR DESCRIPTION
WorkflowRun GC SHOULD Wait all workflowRun related workload pods
deleting completed, then start gc pod to clean date on PV.Otherwise,
if the path which is used by workload pods in the PV is deleted
before workload pods deletion, the pod deletion process will get
stuck on Terminating status.

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @pendoragon @orainxiong 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
