### PR TITLE
fix: update deployment version to satisfy k8s 1.17

### DIFF
--- a/pkg/server/biz/usage/watcher.go
+++ b/pkg/server/biz/usage/watcher.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/caicloud/nirvana/log"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,12 +39,13 @@ func LaunchPVCUsageWatcher(client kubernetes.Interface, tenant string, context v
 	}
 
 	watcherConfig := config.Config.StorageUsageWatcher
-	_, err := client.ExtensionsV1beta1().Deployments(context.Namespace).Create(&v1beta1.Deployment{
+
+	_, err := client.AppsV1().Deployments(context.Namespace).Create(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PVCWatcherName,
 			Namespace: context.Namespace,
 		},
-		Spec: v1beta1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					PVCWatcherLabelName: PVCWatcherLabelValue,
@@ -129,7 +130,7 @@ func getOrDefault(watcherConfig *config.StorageUsageWatcher, key corev1.Resource
 // DeletePVCUsageWatcher delete the pvc usage watcher deployment
 func DeletePVCUsageWatcher(client kubernetes.Interface, namespace string) error {
 	foreground := metav1.DeletePropagationForeground
-	err := client.ExtensionsV1beta1().Deployments(namespace).Delete(PVCWatcherName, &metav1.DeleteOptions{
+	err := client.AppsV1().Deployments(namespace).Delete(PVCWatcherName, &metav1.DeleteOptions{
 		PropagationPolicy: &foreground,
 	})
 
@@ -161,6 +162,6 @@ func DeletePVCUsageWatcher(client kubernetes.Interface, namespace string) error 
 }
 
 // GetPVCUsageWatcher gets the pvc watch dog deployment.
-func GetPVCUsageWatcher(client kubernetes.Interface, namespace string) (*v1beta1.Deployment, error) {
-	return client.ExtensionsV1beta1().Deployments(namespace).Get(PVCWatcherName, metav1.GetOptions{})
+func GetPVCUsageWatcher(client kubernetes.Interface, namespace string) (*appsv1.Deployment, error) {
+	return client.AppsV1().Deployments(namespace).Get(PVCWatcherName, metav1.GetOptions{})
 }

--- a/pkg/server/biz/usage/watcher_test.go
+++ b/pkg/server/biz/usage/watcher_test.go
@@ -35,13 +35,13 @@ func (suite *WatcherSuite) TestLaunchPVCUsageWatcher() {
 	err := LaunchPVCUsageWatcher(suite.client, suite.tenant, context)
 	assert.Nil(suite.T(), err)
 
-	_, err = suite.client.ExtensionsV1beta1().Deployments(context.Namespace).Get(PVCWatcherName, metav1.GetOptions{})
+	_, err = suite.client.AppsV1().Deployments(context.Namespace).Get(PVCWatcherName, metav1.GetOptions{})
 	assert.Nil(suite.T(), err)
 }
 
 func (suite *WatcherSuite) TestDeletePVCUsageWatcher() {
 	testNamespace := "test-namespace"
-	_, err := suite.client.ExtensionsV1beta1().Deployments(testNamespace).Create(&v1beta1.Deployment{
+	_, err := suite.client.AppsV1().Deployments(testNamespace).Create(&v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: PVCWatcherName,
 		},
@@ -53,7 +53,7 @@ func (suite *WatcherSuite) TestDeletePVCUsageWatcher() {
 	err = DeletePVCUsageWatcher(suite.client, testNamespace)
 	assert.Nil(suite.T(), err)
 
-	_, err = suite.client.ExtensionsV1beta1().Deployments(testNamespace).Get(PVCWatcherName, metav1.GetOptions{})
+	_, err = suite.client.AppsV1().Deployments(testNamespace).Get(PVCWatcherName, metav1.GetOptions{})
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "not found")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @iawia002 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
This change will break backwards compatibility that all pvc-uaage wahcer deployments create in the previous version can not be deleted
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
