### PR TITLE
fix: sending ping message for websocket

### DIFF
--- a/build/toolbox/resolver-runner.sh
+++ b/build/toolbox/resolver-runner.sh
@@ -6,7 +6,10 @@ set -o pipefail
 
 function finish {
   echo "sleep 1 second to collect logs"
-  sleep 1
+  sleep 0.5
+  # kill child process fstream
+  pkill -P $$
+  sleep 0.5
 }
 trap finish EXIT
 

--- a/cmd/workflow/coordinator/main.go
+++ b/cmd/workflow/coordinator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/caicloud/cyclone/pkg/common"
+	"github.com/caicloud/cyclone/pkg/common/signals"
 	utilk8s "github.com/caicloud/cyclone/pkg/util/k8s"
 	"github.com/caicloud/cyclone/pkg/workflow/coordinator"
 )
@@ -29,9 +31,13 @@ func main() {
 
 	var err error
 	var message string
+	ctx, cancel := context.WithCancel(context.Background())
+	signals.GracefulShutdown(cancel)
 	defer func() {
 		// graceful showdown, need delay time to collect logs of other containers
-		time.Sleep(exitDelayTime)
+		time.Sleep(exitDelayTime / 3 * 2)
+		cancel()
+		time.Sleep(exitDelayTime / 3)
 		if err != nil {
 			log.Error(message)
 			os.Exit(1)
@@ -49,9 +55,9 @@ func main() {
 	}
 
 	// New workflow stage coordinator.
-	c, err := coordinator.NewCoordinator(client)
+	c, err := coordinator.NewCoordinator(ctx, client)
 	if err != nil {
-		log.Errorf("New coornidator failed: %v", err)
+		log.Errorf("New coordinator failed: %v", err)
 		return
 	}
 

--- a/cmd/workflow/coordinator/main.go
+++ b/cmd/workflow/coordinator/main.go
@@ -35,9 +35,10 @@ func main() {
 	signals.GracefulShutdown(cancel)
 	defer func() {
 		// graceful showdown, need delay time to collect logs of other containers
-		time.Sleep(exitDelayTime / 3 * 2)
+		time.Sleep(exitDelayTime)
 		cancel()
-		time.Sleep(exitDelayTime / 3)
+		// sleep 1 second to let the background processes do exit
+		time.Sleep(time.Second)
 		if err != nil {
 			log.Error(message)
 			os.Exit(1)

--- a/pkg/common/signals/signal.go
+++ b/pkg/common/signals/signal.go
@@ -23,10 +23,10 @@ func GracefulShutdown(cancel context.CancelFunc) {
 	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		s := <-c
-		log.WithField("signal", s).Debug("System signal caught, cancel context.")
+		log.WithField("signal", s).Info("System signal caught, cancel context.")
 		cancel()
 		s = <-c
-		log.WithField("signal", s).Debug("Another system signal caught, exit directly.")
+		log.WithField("signal", s).Info("Another system signal caught, exit directly.")
 		os.Exit(1)
 	}()
 }

--- a/pkg/workflow/coordinator/cycloneserver/client.go
+++ b/pkg/workflow/coordinator/cycloneserver/client.go
@@ -7,8 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	websocketutil "github.com/caicloud/cyclone/pkg/util/websocket"
 )
 
@@ -20,7 +18,7 @@ const (
 
 // Client ...
 type Client interface {
-	PushLogStream(ns, workflowrun, stage, container string, reader io.Reader) error
+	PushLogStream(ns, workflowrun, stage, container string, reader io.Reader, close <-chan struct{}) error
 }
 
 type client struct {
@@ -42,7 +40,7 @@ func NewClient(cycloneServer string) Client {
 }
 
 // PushLogStream ...
-func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader io.Reader) error {
+func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader io.Reader, close <-chan struct{}) error {
 	path := fmt.Sprintf(apiPathForLogStream, workflowrun)
 	host := strings.TrimPrefix(c.baseURL, "http://")
 	host = strings.TrimPrefix(host, "https://")
@@ -53,6 +51,5 @@ func (c *client) PushLogStream(ns, workflowrun, stage, container string, reader 
 		Scheme:   "ws",
 	}
 
-	log.Infof("Path: %s", requestURL.String())
-	return websocketutil.SendStream(requestURL.String(), reader, make(chan struct{}))
+	return websocketutil.SendStream(requestURL.String(), reader, close)
 }

--- a/pkg/workflow/coordinator/k8sapi/k8sapi.go
+++ b/pkg/workflow/coordinator/k8sapi/k8sapi.go
@@ -99,7 +99,7 @@ func (k *Executor) GetPod() (*core_v1.Pod, error) {
 }
 
 // CollectLog collects container logs.
-func (k *Executor) CollectLog(container, workflowrun, stage string) error {
+func (k *Executor) CollectLog(container, workflowrun, stage string, close <-chan struct{}) error {
 	log.Infof("Start to collect %s log", container)
 	stream, err := k.client.CoreV1().Pods(k.namespace).GetLogs(k.podName, &core_v1.PodLogOptions{
 		Container: container,
@@ -115,7 +115,7 @@ func (k *Executor) CollectLog(container, workflowrun, stage string) error {
 		}
 	}()
 
-	err = k.cycloneClient.PushLogStream(k.metaNamespace, workflowrun, stage, container, stream)
+	err = k.cycloneClient.PushLogStream(k.metaNamespace, workflowrun, stage, container, stream, close)
 	if err != nil {
 		return err
 	}
@@ -123,8 +123,8 @@ func (k *Executor) CollectLog(container, workflowrun, stage string) error {
 }
 
 // MarkLogEOF marks the end of stage logs
-func (k *Executor) MarkLogEOF(workflowrun, stage string) error {
-	err := k.cycloneClient.PushLogStream(k.metaNamespace, workflowrun, stage, cyclone_common.FolderEOFFile, strings.NewReader(""))
+func (k *Executor) MarkLogEOF(workflowrun, stage string, close <-chan struct{}) error {
+	err := k.cycloneClient.PushLogStream(k.metaNamespace, workflowrun, stage, cyclone_common.FolderEOFFile, strings.NewReader(""), close)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (k *Executor) CopyFromContainer(container, path, dst string) error {
 	cmd := exec.Command("docker", args...)
 	log.WithField("args", args).Info()
 	ret, err := cmd.CombinedOutput()
-	log.WithField("message", string(ret)).WithField("error", err).Info("copy file result")
+	log.WithField("message", string(ret)).WithField("error", err).WithField("container", container).Info("copy file result")
 	if err != nil {
 		return fmt.Errorf("%s, error: %v", string(ret), err)
 	}


### PR DESCRIPTION
- Stream logs receiver sends ping message periodically to keep the
connection not idle. The reason why we need this is sender peer may
stuck on reading kubernetes stream logs and could not have a chance
to send ping message periodically.

- Add somes logs

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @hyy0322 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
