### PR TITLE
fix: delay to close websocket

### DIFF
--- a/pkg/server/handler/v1alpha1/workflowrun.go
+++ b/pkg/server/handler/v1alpha1/workflowrun.go
@@ -492,7 +492,7 @@ func getContainerLogStream(tenant, project, workflow, workflowrun, stage string,
 
 	go watchStageTermination(common.TenantNamespace(tenant), workflowrun, stage, cancel)
 
-	err = websocketutil.Write(ws, folderReader, ctx.Done())
+	err = websocketutil.Write(ws, folderReader, ctx.Done(), 60)
 	if err != nil {
 		log.Error("websocket writer error:", err)
 	}

--- a/pkg/util/websocket/websocket.go
+++ b/pkg/util/websocket/websocket.go
@@ -83,7 +83,7 @@ func SendStream(server string, reader io.Reader, close <-chan struct{}) error {
 // Send sends stream from reader by websocket
 func Send(ws *websocket.Conn, reader io.Reader, close <-chan struct{}) error {
 	buf := bufio.NewReader(reader)
-	err := Write(ws, buf, close)
+	err := Write(ws, buf, close, 1)
 	if err != nil {
 		log.Error("websocket writer error:", err)
 	}
@@ -98,7 +98,7 @@ type ReadBytes interface {
 }
 
 // Write writes message from reader to websocket
-func Write(ws *websocket.Conn, reader ReadBytes, stop <-chan struct{}) error {
+func Write(ws *websocket.Conn, reader ReadBytes, stop <-chan struct{}, stopDelaySeconds time.Duration) error {
 	go func() {
 		// Handle ping message send by peer, since the ping Handler function will be
 		// called from the NextReader, ReadMessage and message reader Read methods.
@@ -179,6 +179,8 @@ func Write(ws *websocket.Conn, reader ReadBytes, stop <-chan struct{}) error {
 			}
 		case <-stop:
 			log.Info("receive stop signal")
+			// Sleep "stopDelaySeconds" to wait sending things
+			time.Sleep(time.Duration(stopDelaySeconds * time.Second))
 			if err := ws.SetWriteDeadline(time.Now().Add(WriteWait)); err != nil {
 				log.Warning("set write deadline error:", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

The cyclone server will close the web socket immediately when it watches the log completed.
But we expect to leave some seconds to sending logs before the web socket closing.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @hyy0322 @qiuxiaolian 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
