### PR TITLE
fix: status wrong when task processed in the delegation api

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,20 @@
+package util
+
+import "github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+
+// IsWorkflowRunTerminated judges whether the WorkflowRun has be terminated.
+// Return true if terminated, otherwise return false.
+func IsWorkflowRunTerminated(wfr *v1alpha1.WorkflowRun) bool {
+	return IsPhaseTerminated(wfr.Status.Overall.Phase)
+}
+
+// IsPhaseTerminated judges whether the phase is terminated
+func IsPhaseTerminated(phase v1alpha1.StatusPhase) bool {
+	if phase == v1alpha1.StatusSucceeded ||
+		phase == v1alpha1.StatusFailed ||
+		phase == v1alpha1.StatusCancelled {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+)
+
+func TestIsWorkflowRunTerminated(t *testing.T) {
+	wfr := &v1alpha1.WorkflowRun{
+		Status: v1alpha1.WorkflowRunStatus{
+			Overall: v1alpha1.Status{},
+		},
+	}
+
+	testCases := map[v1alpha1.StatusPhase]struct {
+		phase    v1alpha1.StatusPhase
+		expected bool
+	}{
+		v1alpha1.StatusPending: {
+			v1alpha1.StatusPending,
+			false,
+		},
+		v1alpha1.StatusRunning: {
+			v1alpha1.StatusRunning,
+			false,
+		},
+		v1alpha1.StatusWaiting: {
+			v1alpha1.StatusWaiting,
+			false,
+		},
+		v1alpha1.StatusSucceeded: {
+			v1alpha1.StatusSucceeded,
+			true,
+		},
+		v1alpha1.StatusFailed: {
+			v1alpha1.StatusFailed,
+			true,
+		},
+		v1alpha1.StatusCancelled: {
+			v1alpha1.StatusCancelled,
+			true,
+		},
+	}
+
+	for d, tc := range testCases {
+		wfr.Status.Overall.Phase = tc.phase
+		result := IsWorkflowRunTerminated(wfr)
+		if result != tc.expected {
+			t.Errorf("Fail to judge the status for %s: expect %t, but got %t", d, tc.expected, result)
+		}
+	}
+}

--- a/pkg/workflow/controller/handlers/pod/operation.go
+++ b/pkg/workflow/controller/handlers/pod/operation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
+	"github.com/caicloud/cyclone/pkg/util"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
 	"github.com/caicloud/cyclone/pkg/workflow/controller"
 	"github.com/caicloud/cyclone/pkg/workflow/workflowrun"
@@ -104,9 +105,7 @@ func (p *Operator) OnUpdated() error {
 	}
 
 	// If the WorkflowRun has already been in terminated state, skip it.
-	if origin.Status.Overall.Phase == v1alpha1.StatusSucceeded ||
-		origin.Status.Overall.Phase == v1alpha1.StatusFailed ||
-		origin.Status.Overall.Phase == v1alpha1.StatusCancelled {
+	if util.IsWorkflowRunTerminated(origin) {
 		return nil
 	}
 

--- a/pkg/workflow/controller/handlers/workflowrun/handler.go
+++ b/pkg/workflow/controller/handlers/workflowrun/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
 	"github.com/caicloud/cyclone/pkg/meta"
+	"github.com/caicloud/cyclone/pkg/util"
 	utilhttp "github.com/caicloud/cyclone/pkg/util/http"
 	"github.com/caicloud/cyclone/pkg/workflow/common"
 	"github.com/caicloud/cyclone/pkg/workflow/controller"
@@ -99,7 +100,7 @@ func (h *Handler) Reconcile(obj interface{}) error {
 
 	// If the WorkflowRun has already been terminated(Completed, Failed, Cancelled), send notifications if necessary,
 	// otherwise directly skip it.
-	if workflowrun.IsWorkflowRunTerminated(originWfr) {
+	if util.IsWorkflowRunTerminated(originWfr) {
 		// If the WorkflowRun already terminated, mark it in the ParallelismController.
 		h.ParallelismController.MarkFinished(originWfr.Namespace, originWfr.Spec.WorkflowRef.Name, originWfr.Name)
 

--- a/pkg/workflow/workflowrun/utils.go
+++ b/pkg/workflow/workflowrun/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
+	"github.com/caicloud/cyclone/pkg/util"
 )
 
 // resolveStatus determines the final status from two given status, one is latest status, and
@@ -16,13 +17,13 @@ import (
 func resolveStatus(latest, update *v1alpha1.Status) *v1alpha1.Status {
 	// If the latest status is already a terminated status (Completed, Failed, Cancelled), no need to
 	// update it, we just return the latest status.
-	if latest.Phase == v1alpha1.StatusSucceeded || latest.Phase == v1alpha1.StatusFailed || latest.Phase == v1alpha1.StatusCancelled {
+	if util.IsPhaseTerminated(latest.Phase) {
 		return latest
 	}
 
 	// If the latest status is not a terminated status, but the reported status is, then we
 	// apply the reported status.
-	if update.Phase == v1alpha1.StatusSucceeded || update.Phase == v1alpha1.StatusFailed || latest.Phase == v1alpha1.StatusCancelled {
+	if util.IsPhaseTerminated(update.Phase) {
 		return update
 	}
 
@@ -132,18 +133,6 @@ func ensureOwner(client clientset.Interface, wf *v1alpha1.Workflow, wfr *v1alpha
 	})
 
 	return nil
-}
-
-// IsWorkflowRunTerminated judges whether the WorkflowRun has be terminated.
-// Return true if terminated, otherwise return false.
-func IsWorkflowRunTerminated(wfr *v1alpha1.WorkflowRun) bool {
-	if wfr.Status.Overall.Phase == v1alpha1.StatusSucceeded ||
-		wfr.Status.Overall.Phase == v1alpha1.StatusFailed ||
-		wfr.Status.Overall.Phase == v1alpha1.StatusCancelled {
-		return true
-	}
-
-	return false
 }
 
 // GCPodName generates a pod name for GC pod

--- a/pkg/workflow/workflowrun/utils_test.go
+++ b/pkg/workflow/workflowrun/utils_test.go
@@ -222,52 +222,6 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "default:test", item.String())
 }
 
-func TestIsWorkflowRunTerminated(t *testing.T) {
-	wfr := &v1alpha1.WorkflowRun{
-		Status: v1alpha1.WorkflowRunStatus{
-			Overall: v1alpha1.Status{},
-		},
-	}
-
-	testCases := map[v1alpha1.StatusPhase]struct {
-		phase    v1alpha1.StatusPhase
-		expected bool
-	}{
-		v1alpha1.StatusPending: {
-			v1alpha1.StatusPending,
-			false,
-		},
-		v1alpha1.StatusRunning: {
-			v1alpha1.StatusRunning,
-			false,
-		},
-		v1alpha1.StatusWaiting: {
-			v1alpha1.StatusWaiting,
-			false,
-		},
-		v1alpha1.StatusSucceeded: {
-			v1alpha1.StatusSucceeded,
-			true,
-		},
-		v1alpha1.StatusFailed: {
-			v1alpha1.StatusFailed,
-			true,
-		},
-		v1alpha1.StatusCancelled: {
-			v1alpha1.StatusCancelled,
-			true,
-		},
-	}
-
-	for d, tc := range testCases {
-		wfr.Status.Overall.Phase = tc.phase
-		result := IsWorkflowRunTerminated(wfr)
-		if result != tc.expected {
-			t.Errorf("Fail to judge the status for %s: expect %t, but got %t", d, tc.expected, result)
-		}
-	}
-}
-
 func TestGCPodName(t *testing.T) {
 	assert.Equal(t, GCPodName("wfr"), "wfrgc--wfr")
 }

--- a/pkg/workflow/workflowrun/workload.go
+++ b/pkg/workflow/workflowrun/workload.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
 	"github.com/caicloud/cyclone/pkg/k8s/clientset"
+	"github.com/caicloud/cyclone/pkg/util"
 	"github.com/caicloud/cyclone/pkg/util/retry"
 	"github.com/caicloud/cyclone/pkg/workflow/workload/delegation"
 	"github.com/caicloud/cyclone/pkg/workflow/workload/pod"
@@ -153,9 +154,7 @@ func (p *WorkloadProcessor) processDelegation() error {
 	}
 	// The task maybe has been processed by the delegation task and status not needed to be set to Waiting
 	if stg, ok := latestWfr.Status.Stages[p.stg.Name]; ok {
-		if stg.Status.Phase == v1alpha1.StatusSucceeded ||
-			stg.Status.Phase == v1alpha1.StatusFailed ||
-			stg.Status.Phase == v1alpha1.StatusCancelled {
+		if util.IsPhaseTerminated(stg.Status.Phase) {
 			return nil
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

If the delegation task processed in the delegation API and update the task status to Succeeded/Failed status, we should not update it to Waiting(since the task has already been processed), otherwise, the task will be stuck.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @hyy0322 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
