### PR TITLE
feat: support bitbucket triggers workflows by hooks

### DIFF
--- a/pkg/server/biz/scm/bitbucket/bitbucket.go
+++ b/pkg/server/biz/scm/bitbucket/bitbucket.go
@@ -25,6 +25,12 @@ const (
 
 	// EventTypeHeader represents the header key for event type of Bitbucket.
 	EventTypeHeader = "X-Event-Key"
+
+	// HookEventHeader represent the header key to decide whether it is a bitbucket hook event
+	// value could be true or false
+	HookEventHeader = "X-BitBucket-Hook-Event"
+	// ServerAddressHeader represent the header key of bitbucket server address
+	ServerAddressHeader = "X-Server-Address"
 )
 
 func init() {
@@ -133,4 +139,9 @@ func ParseEvent(scmCfg *v1alpha1.SCMSource, request *http.Request) *scm.EventDat
 		log.Errorln(err)
 		return nil
 	}
+}
+
+// ParseHookEvent parses data from Bitbucket events.
+func ParseHookEvent(request *http.Request) *scm.EventData {
+	return server.ParseEvent(request)
 }

--- a/pkg/server/biz/scm/bitbucket/server/webhooks.go
+++ b/pkg/server/biz/scm/bitbucket/server/webhooks.go
@@ -66,13 +66,14 @@ func ParseEvent(request *http.Request) *scm.EventData {
 	}
 	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		log.Errorln(err)
+		log.Errorf("read request body error: %v", err)
 		return nil
 	}
+	log.Errorf("Test read body: %s", string(body))
 	var payload EventPayload
 	err = json.Unmarshal(body, &payload)
 	if err != nil {
-		log.Errorln(err)
+		log.Errorf("Unmarshal body error: %v", err)
 		return nil
 	}
 	switch eventKey {

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -68,6 +68,21 @@ type CycloneServerConfig struct {
 	// ClientSet holds the common attributes that can be passed to a Kubernetes client on cyclone server handlers
 	// initialization.
 	ClientSet ClientSetConfig `json:"client_set"`
+
+	// Webhook contains configurations for webhook auto trigger.
+	Webhook WebhookConfig `json:"webhook"`
+}
+
+// WebhookConfig describes configuration for webhook auto trigger.
+type WebhookConfig struct {
+	// BitBucket webhook config
+	BitBucket WebhookBitBucketConfig `json:"bitbucket"`
+}
+
+// WebhookBitBucketConfig describes configuration for webhook to trigger bitbucket type workflows.
+type WebhookBitBucketConfig struct {
+	// MatchSpecificTenantForHooks defines whether to match workflows for all tenants or for a specific tenant.
+	MatchSpecificTenantForHooks bool `json:"matchSpecificTenantForHooks"`
 }
 
 // ClientSetConfig defines rate limit config for a Kubernetes client

--- a/pkg/server/handler/v1alpha1/tenant.go
+++ b/pkg/server/handler/v1alpha1/tenant.go
@@ -294,3 +294,22 @@ func createTenant(t *api.Tenant) error {
 
 	return nil
 }
+
+// getAllTenantsName get all tenants name
+func getAllTenantsName() ([]string, error) {
+	tenants := make([]string, 0)
+	namespaces, err := handler.K8sClient.CoreV1().Namespaces().List(meta_v1.ListOptions{
+		LabelSelector: meta.LabelTenantName,
+	})
+	if err != nil {
+		return tenants, cerr.ConvertK8sError(err)
+	}
+
+	for _, namespace := range namespaces.Items {
+		if namespace.Labels == nil {
+			continue
+		}
+		tenants = append(tenants, namespace.Labels[meta.LabelTenantName])
+	}
+	return tenants, nil
+}


### PR DESCRIPTION
BitBucket version smaller than 5.4 can not support webhooks, we
suppose these bitbucket can use hooks, like ScriptRunner, to send
a post request to cyclone server when some events happened, and
the cyclone server will handle the request and trigger workflows.

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add your description

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @hyy0322 @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
