### PR TITLE
fix: add workflow name info for pods created by cyclone

### DIFF
--- a/pkg/workflow/common/const.go
+++ b/pkg/workflow/common/const.go
@@ -20,6 +20,10 @@ const (
 	EnvWorkflowRunInfo = "WORKFLOWRUN_INFO"
 	// EnvOutputResourcesInfo is an environment which represents output resources information.
 	EnvOutputResourcesInfo = "OUTPUT_RESOURCES_INFO"
+	// EnvProjectName is an environment which represents project name.
+	EnvProjectName = "PROJECT_NAME"
+	// EnvWorkflowName is an environment which represents workflow name.
+	EnvWorkflowName = "WORKFLOW_NAME"
 	// EnvWorkflowrunName is an environment which represents workflowrun name.
 	EnvWorkflowrunName = "WORKFLOWRUN_NAME"
 	// EnvStageName is an environment which represents stage name.

--- a/pkg/workflow/common/owner.go
+++ b/pkg/workflow/common/owner.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"reflect"
+
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+	"github.com/caicloud/cyclone/pkg/meta"
+)
+
+// ResolveWorkflowName finds workflow name in the workflowRun's filed in order
+// - WorkflowRef
+// - OwnerReference
+// - Label workflow
+// if found returns the value, otherwise returns empty.
+func ResolveWorkflowName(wfr v1alpha1.WorkflowRun) string {
+	workflowKind := reflect.TypeOf(v1alpha1.Workflow{}).Name()
+	if wfr.Spec.WorkflowRef != nil && wfr.Spec.WorkflowRef.Kind == workflowKind {
+		return wfr.Spec.WorkflowRef.Name
+	}
+
+	for _, or := range wfr.OwnerReferences {
+		if or.Kind == workflowKind {
+			return or.Name
+		}
+	}
+
+	if wfr.Labels != nil {
+		if n, ok := wfr.Labels[meta.LabelWorkflowName]; ok {
+			return n
+		}
+	}
+	return ""
+}
+
+// ResolveProjectName finds project name in the workflowRun's label,
+// if found returns the value, otherwise returns empty.
+func ResolveProjectName(wfr v1alpha1.WorkflowRun) string {
+	if wfr.Labels != nil {
+		if n, ok := wfr.Labels[meta.LabelProjectName]; ok {
+			return n
+		}
+	}
+	return ""
+}

--- a/pkg/workflow/common/owner_test.go
+++ b/pkg/workflow/common/owner_test.go
@@ -1,0 +1,90 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/caicloud/cyclone/pkg/meta"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/caicloud/cyclone/pkg/apis/cyclone/v1alpha1"
+)
+
+func TestResolveWorkflowName(t *testing.T) {
+
+	cases := map[string]struct {
+		wfr    v1alpha1.WorkflowRun
+		expect string
+	}{
+		"wfrRef": {
+			wfr: v1alpha1.WorkflowRun{
+				Spec: v1alpha1.WorkflowRunSpec{
+					WorkflowRef: &corev1.ObjectReference{
+						Kind: "Workflow",
+						Name: "w1",
+					},
+				},
+			},
+			expect: "w1",
+		},
+		"wfrOwner": {
+			wfr: v1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Workflow",
+							Name: "w1",
+						}},
+				},
+			},
+			expect: "w1",
+		},
+		"label": {
+			wfr: v1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						meta.LabelWorkflowName: "w1",
+					},
+				},
+			},
+			expect: "w1",
+		},
+		"none": {
+			wfr:    v1alpha1.WorkflowRun{},
+			expect: "",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expect, ResolveWorkflowName(c.wfr))
+	}
+}
+
+func TestResolveProjectName(t *testing.T) {
+
+	cases := map[string]struct {
+		wfr    v1alpha1.WorkflowRun
+		expect string
+	}{
+		"label": {
+			wfr: v1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						meta.LabelProjectName: "p1",
+					},
+				},
+			},
+			expect: "p1",
+		},
+		"none": {
+			wfr:    v1alpha1.WorkflowRun{},
+			expect: "",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expect, ResolveProjectName(c.wfr))
+	}
+}

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -512,6 +512,8 @@ func (o *operator) GC(lastTry, wfrDeletion bool) error {
 				Name:      GCPodName(o.wfr.Name),
 				Namespace: executionContext.Namespace,
 				Labels: map[string]string{
+					meta.LabelProjectName:     common.ResolveProjectName(*o.wfr),
+					meta.LabelWorkflowName:    common.ResolveWorkflowName(*o.wfr),
 					meta.LabelWorkflowRunName: o.wfr.Name,
 					meta.LabelPodKind:         meta.PodKindGC.String(),
 					meta.LabelPodCreatedBy:    meta.CycloneCreator,

--- a/pkg/workflow/workload/pod/builder.go
+++ b/pkg/workflow/workload/pod/builder.go
@@ -81,6 +81,8 @@ func (m *Builder) Prepare() error {
 		Name:      Name(m.wf.Name, m.stage),
 		Namespace: m.executionContext.Namespace,
 		Labels: map[string]string{
+			meta.LabelProjectName:     common.ResolveProjectName(*m.wfr),
+			meta.LabelWorkflowName:    common.ResolveWorkflowName(*m.wfr),
 			meta.LabelWorkflowRunName: m.wfr.Name,
 			meta.LabelPodCreatedBy:    meta.CycloneCreator,
 			meta.LabelPodKind:         meta.PodKindWorkload.String(),
@@ -841,6 +843,14 @@ func (m *Builder) AddCoordinator() error {
 // stage name, namespace.
 func (m *Builder) InjectEnvs() error {
 	envs := []corev1.EnvVar{
+		{
+			Name:  common.EnvProjectName,
+			Value: common.ResolveProjectName(*m.wfr),
+		},
+		{
+			Name:  common.EnvWorkflowName,
+			Value: common.ResolveWorkflowName(*m.wfr),
+		},
 		{
 			Name:  common.EnvWorkflowrunName,
 			Value: m.wfr.Name,

--- a/pkg/workflow/workload/pod/builder_test.go
+++ b/pkg/workflow/workload/pod/builder_test.go
@@ -57,6 +57,10 @@ var tmp2 = "v1"
 var wfr = &v1alpha1.WorkflowRun{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "wfr",
+		Labels: map[string]string{
+			meta.LabelProjectName:  "p1",
+			meta.LabelWorkflowName: "wf",
+		},
 	},
 	Spec: v1alpha1.WorkflowRunSpec{
 		Stages: []v1alpha1.ParameterConfig{
@@ -613,6 +617,29 @@ func (suite *PodBuilderSuite) TestAddCommonVolumes() {
 			MountPath: "/tmp",
 			ReadOnly:  true,
 		})
+	}
+}
+
+func (suite *PodBuilderSuite) TestInjectEnvs() {
+	builder := NewBuilder(suite.client, wf, wfr, getStage(suite.client, "simple"))
+	err := builder.Prepare()
+	assert.Nil(suite.T(), err)
+	err = builder.ResolveArguments()
+	assert.Nil(suite.T(), err)
+	err = builder.InjectEnvs()
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), builder.pod.Spec.Containers[0].Env)
+	for _, kv := range builder.pod.Spec.Containers[0].Env {
+		switch kv.Name {
+		case common.EnvProjectName:
+			assert.Equal(suite.T(), "p1", kv.Value)
+		case common.EnvWorkflowName:
+			assert.Equal(suite.T(), "wf", kv.Value)
+		case common.EnvWorkflowrunName:
+			assert.Equal(suite.T(), "wfr", kv.Value)
+		case common.EnvStageName:
+			assert.Equal(suite.T(), "simple", kv.Value)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add workflow name info for pods created by cyclone

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
