### PR TITLE
fix(resolver::git): refine repos cloning and fix `git checkout`

### DIFF
--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -124,8 +124,6 @@ modifyURL() {
 }
 
 wrapPull() {
-    local count
-    local res=0
     # If there is already data, we should just wait for the data to be ready.
     if [ -e $WORKDIR/data ]; then
         echo "Found data, wait it to be ready..."
@@ -142,13 +140,7 @@ wrapPull() {
         failed=$(mkdir $PULLING_LOCK > /dev/null 2>&1 || echo fail)
         if [[ $failed != "fail" ]]; then
             echo "Got the lock, start to pulling..."
-            pull || res=$?
-            if [ $res -eq 99 ] && [ "${SCM_TYPE}" == "Bitbucket" ]; then
-                echo "Fail to pull with depth flag, retry without depth flag..."
-                unset GIT_DEPTH_OPTION
-                unset GIT_DEPTH_OPTION_DEEPER
-                pull
-            fi
+            pull
         else
             echo "Failed to get the lock, wait others to finish pulling..."
             while [ -d $PULLING_LOCK ]
@@ -177,46 +169,37 @@ parseRevision() {
 }
 parseRevision
 
-parseCloneRes() {
-    local clone_log=$1
-    local clone_res=$2
-    cat $clone_log
-    if [ $clone_res -ne 0 ]; then
-        if grep "The requested URL returned error: 500" $clone_log > /dev/null 2>&1; then
-            # use code 99 for git clone --depth fail
-            rm -f $clone_log
-            return 99
-        else
-            exit $clone_res
-        fi
-    fi
-    return 0
+retryGitOpWithoutDepthFlagIfFromBitbucket() {
+  local op="$1"
+  shift
+  if (! git "$op" ${GIT_DEPTH_OPTION:-} "$@") && [[ ${SCM_TYPE} == 'Bitbucket' ]]; then
+    echo "Fail to pull with depth flag, retry without depth flag..."
+    git "$op" "$@"
+  fi
 }
 
 pull() {
-    local parse_res
-    local clone_res
     git config --global http.sslVerify false
     git config --global http.postBuffer 500M
     NO_AUTH_SCM_URL=${SCM_URL}
     # If data existed and pull policy is IfNotPresent, perform incremental pull.
-    if [ -e $WORKDIR/data ] && [ ${PULL_POLICY:=Always} == "IfNotPresent" ]; then
-        cd $WORKDIR/data
+    if [ -e "$WORKDIR/data" ] && [ ${PULL_POLICY:=Always} == "IfNotPresent" ]; then
+        cd "$WORKDIR/data"
         # Ensure existed data come from the git repo
-        git remote -v | grep ${SCM_URL##*//} || {
+        git remote -v | grep "${SCM_URL##*//}" || {
             echo "Existed data not a valid git repo for ${SCM_URL##*//}"
             exit 1
         }
 
         echo "Fetch $SCM_REVISION from origin"
-        git fetch -v ${GIT_DEPTH_OPTION:-} origin $SCM_REVISION
+        retryGitOpWithoutDepthFlagIfFromBitbucket fetch -v origin "$SCM_REVISION"
         git checkout FETCH_HEAD
     else
-        if [ -e $WORKDIR/data ]; then
+        if [ -e "$WORKDIR/data" ]; then
             echo "Clean old data ($WORKDIR/data) when pull policy is Always"
-            rm -rf $WORKDIR/data
+            rm -rf "$WORKDIR/data"
         fi
-        cd $WORKDIR
+        cd "$WORKDIR"
 
         # Add auth to url if provided and clone git repo. If SCM_AUTH is in format '<user>:<password>', then url
         # encode each part of it and get '<encoded_user>:<encoded_password>'. If SCM_AUTH is in format '<token>',
@@ -232,15 +215,11 @@ pull() {
             mkdir data && cd data
             git init
             git remote add origin "${SCM_URL_MODIFIED}"
-            git fetch ${GIT_DEPTH_OPTION:-} origin "$SOURCE_BRANCH"
+            retryGitOpWithoutDepthFlagIfFromBitbucket fetch origin "$SOURCE_BRANCH"
             git checkout -q FETCH_HEAD
         else
             echo "Merge $SOURCE_BRANCH to $TARGET_BRANCH..."
-            git clone -v -b $TARGET_BRANCH ${GIT_DEPTH_OPTION:-} --single-branch --recursive ${SCM_URL_MODIFIED} data > clone_result.log 2>&1; clone_res=$?
-            parseCloneRes clone_result.log $clone_res; parse_res=$?
-            if [ $parse_res -ne 0 ]; then
-                return $parse_res
-            fi
+            retryGitOpWithoutDepthFlagIfFromBitbucket clone -v -b "$TARGET_BRANCH" --single-branch --recursive "${SCM_URL_MODIFIED}" data
             cd data
             git config user.email "cicd@cyclone.dev"
             git config user.name "cicd"

--- a/build/resolver/git/entrypoint.sh
+++ b/build/resolver/git/entrypoint.sh
@@ -227,14 +227,13 @@ pull() {
 
         if [[ "${SOURCE_BRANCH}" == "${TARGET_BRANCH}" ]]; then
             echo "Clone $SOURCE_BRANCH..."
-            git clone -v -b master ${GIT_DEPTH_OPTION:-} --single-branch --recursive ${SCM_URL_MODIFIED} data > clone_result.log 2>&1; clone_res=$?
-            parseCloneRes clone_result.log $clone_res; parse_res=$?
-            if [ $parse_res -ne 0 ]; then
-                return $parse_res
-            fi
-            cd data
-            git fetch ${GIT_DEPTH_OPTION:-} origin $SOURCE_BRANCH
-            git checkout -qf FETCH_HEAD
+            # We don't want to use `git clone` here, as $SOURCE_BRANCH could be something like "refs/heads/master",
+            # but `git clone` only supports branch name or tag name.
+            mkdir data && cd data
+            git init
+            git remote add origin "${SCM_URL_MODIFIED}"
+            git fetch ${GIT_DEPTH_OPTION:-} origin "$SOURCE_BRANCH"
+            git checkout -q FETCH_HEAD
         else
             echo "Merge $SOURCE_BRANCH to $TARGET_BRANCH..."
             git clone -v -b $TARGET_BRANCH ${GIT_DEPTH_OPTION:-} --single-branch --recursive ${SCM_URL_MODIFIED} data > clone_result.log 2>&1; clone_res=$?


### PR DESCRIPTION

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Simplify the way we clone repos, and don't pass `-f` to `git checkout`
so that git won't fail silently.

Manual validation:

### branch:
```
Trying to acquire lock and pull resource
Got the lock, start to pulling...
Clone refs/heads/master...
Initialized empty Git repository in /workspace/data/.git/
From http://<redacted>/root/golangtest
 * branch            master     -> FETCH_HEAD
 * [new branch]      master     -> origin/master
total 1
drwxr-xr-x 1 root root   3 Oct 27 14:30 .
drwxr-xr-x 1 root root   2 Oct 27 14:30 ..
drwxr-xr-x 1 root root  12 Oct 27 14:30 .git
-rw-r--r-- 1 root root 249 Oct 27 14:30 Dockerfile
drwxr-xr-x 1 root root   2 Oct 27 14:30 helloworld
Collect commit id to result file /__result__ ...
LastCommitID:c1078d2b17aa201f26e2daf4d74437b5df2eb169
Remove the created lock folder
```

### tag
```
Trying to acquire lock and pull resource
Got the lock, start to pulling...
Clone refs/tags/v0.0.1...
Initialized empty Git repository in /workspace/data/.git/
From http://<redacted>/root/golangtest
 * tag               v0.0.1     -> FETCH_HEAD
total 1
drwxr-xr-x 1 root root   3 Oct 27 14:33 .
drwxr-xr-x 1 root root   2 Oct 27 14:33 ..
drwxr-xr-x 1 root root  12 Oct 27 14:33 .git
-rw-r--r-- 1 root root 249 Oct 27 14:33 Dockerfile
drwxr-xr-x 1 root root   2 Oct 27 14:33 helloworld
Collect commit id to result file /__result__ ...
LastCommitID:c1078d2b17aa201f26e2daf4d74437b5df2eb169
Remove the created lock folder
```

### pull request
```
Trying to acquire lock and pull resource
Got the lock, start to pulling...
Merge refs/merge-requests/1/head to master...
Cloning into 'data'...
POST git-upload-pack (192 bytes)
POST git-upload-pack (201 bytes)
From http://<redacted>/root/golangtest
 * branch            refs/merge-requests/1/head -> FETCH_HEAD
Automatic merge went well; stopped before committing as requested
total 1
drwxr-xr-x 1 root root   3 Oct 27 14:37 .
drwxr-xr-x 1 root root   3 Oct 27 14:37 ..
drwxr-xr-x 1 root root  16 Oct 27 14:37 .git
-rw-r--r-- 1 root root 250 Oct 27 14:37 Dockerfile
drwxr-xr-x 1 root root   2 Oct 27 14:37 helloworld
Collect commit id to result file /__result__ ...
LastCommitID:c1078d2b17aa201f26e2daf4d74437b5df2eb169
Remove the created lock folder
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
