### PR TITLE
fix(bitbucket): correct webhook event

### DIFF
--- a/pkg/server/biz/scm/bitbucket/server/repos_webhooks.go
+++ b/pkg/server/biz/scm/bitbucket/server/repos_webhooks.go
@@ -12,9 +12,11 @@ const (
 	RefsChanged = "repo:refs_changed"
 	// PrOpened is the event key about pull request opened.
 	PrOpened = "pr:opened"
-	// PrModified is the event key about pull request modified.
+	// PrModified means a pull request's description, title, or target branch is changed.
 	// It be supported after the version is 5.10. Ref to: https://confluence.atlassian.com/bitbucketserver/bitbucket-server-5-10-release-notes-948214779.html
 	PrModified = "pr:modified"
+	// PrFromRefUpdated means a pull request's source branch has been updated.
+	PrFromRefUpdated = "pr:from_ref_updated"
 	// PrCommentAdded is the event key about a comment added on the pull request.
 	PrCommentAdded = "pr:comment:added"
 )

--- a/pkg/server/biz/scm/bitbucket/server/webhooks.go
+++ b/pkg/server/biz/scm/bitbucket/server/webhooks.go
@@ -24,10 +24,11 @@ const (
 )
 
 var supportEventMap = map[string]bool{
-	RefsChanged:    true,
-	PrOpened:       true,
-	PrModified:     true,
-	PrCommentAdded: true,
+	RefsChanged:      true,
+	PrOpened:         true,
+	PrModified:       true,
+	PrFromRefUpdated: true,
+	PrCommentAdded:   true,
 }
 
 // EventPayload represents the event information.
@@ -107,7 +108,7 @@ func ParseEvent(request *http.Request) *scm.EventData {
 			CommitSHA: payload.PullRequest.FromRef.LatestCommit,
 			Branch:    payload.PullRequest.ToRef.DisplayID,
 		}
-	case PrModified:
+	case PrFromRefUpdated, PrModified:
 		return &scm.EventData{
 			Type:      scm.PullRequestEventType,
 			Repo:      fmt.Sprintf("%s/%s", strings.ToLower(payload.PullRequest.ToRef.Repository.Project.Key), payload.PullRequest.ToRef.Repository.Slug),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

We actually want to trigger pipeline on `pr:from_ref_updated` event
rather than `pr:modified`.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
bitbucket: fix a bug that PR commits won't trigger pipeline.
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
