### PR TITLE
Ensure workflowRun controller return immediately after updating

### DIFF
--- a/pkg/workflow/controller/controllers/controller.go
+++ b/pkg/workflow/controller/controllers/controller.go
@@ -120,7 +120,8 @@ func (c *Controller) doWork(key string) (res controller.Result, err error) {
 	}
 
 	// Add finalizer if needed
-	if err := c.eventHandler.AddFinalizer(object); err != nil {
+	added, err := c.eventHandler.AddFinalizer(object)
+	if err != nil || added {
 		return res, err
 	}
 

--- a/pkg/workflow/controller/handlers/configmap/handler.go
+++ b/pkg/workflow/controller/handlers/configmap/handler.go
@@ -47,8 +47,8 @@ func (h *Handler) process(obj interface{}) error {
 }
 
 // AddFinalizer adds finalizers to the object and update the object to the Kubernetes.
-func (h *Handler) AddFinalizer(obj interface{}) error {
-	return nil
+func (h *Handler) AddFinalizer(obj interface{}) (bool, error) {
+	return false, nil
 }
 
 // HandleFinalizer does the finalizer key representing things.

--- a/pkg/workflow/controller/handlers/executioncluster/handler.go
+++ b/pkg/workflow/controller/handlers/executioncluster/handler.go
@@ -63,15 +63,15 @@ func (h *Handler) finalize(ec *v1alpha1.ExecutionCluster) error {
 }
 
 // AddFinalizer adds a finalizer to the object and update the object to the Kubernetes.
-func (h *Handler) AddFinalizer(obj interface{}) error {
+func (h *Handler) AddFinalizer(obj interface{}) (bool, error) {
 	originCluster, ok := obj.(*v1alpha1.ExecutionCluster)
 	if !ok {
 		log.WithField("obj", obj).Warning("Expect ExecutionCluster, got unknown type resource")
-		return fmt.Errorf("unknown resource type")
+		return false, fmt.Errorf("unknown resource type")
 	}
 
 	if sets.NewString(originCluster.Finalizers...).Has(finalizerExecutioncluster) {
-		return nil
+		return false, nil
 	}
 
 	log.WithField("name", originCluster.Name).Debug("Start to add finalizer for executionCluster")
@@ -79,7 +79,7 @@ func (h *Handler) AddFinalizer(obj interface{}) error {
 	ec := originCluster.DeepCopy()
 	ec.ObjectMeta.Finalizers = append(ec.ObjectMeta.Finalizers, finalizerExecutioncluster)
 	_, err := h.Client.CycloneV1alpha1().ExecutionClusters().Update(context.TODO(), ec, metav1.UpdateOptions{})
-	return err
+	return true, err
 }
 
 // HandleFinalizer does the finalizer key representing things.

--- a/pkg/workflow/controller/handlers/interface.go
+++ b/pkg/workflow/controller/handlers/interface.go
@@ -12,7 +12,7 @@ type Interface interface {
 
 	// AddFinalizer adds a finalizer to the object if it not exists,
 	// If a finalizer added, this func needs to update the object to the Kubernetes.
-	AddFinalizer(obj interface{}) error
+	AddFinalizer(obj interface{}) (added bool, err error)
 
 	// HandleFinalizer needs to do things:
 	// - execute the finalizer, like deleting any external resources associated with the obj

--- a/pkg/workflow/controller/handlers/workflowrun/handler.go
+++ b/pkg/workflow/controller/handlers/workflowrun/handler.go
@@ -171,15 +171,15 @@ func (h *Handler) finalize(wfr *v1alpha1.WorkflowRun) error {
 }
 
 // AddFinalizer adds a finalizer to the object and update the object to the Kubernetes.
-func (h *Handler) AddFinalizer(obj interface{}) error {
+func (h *Handler) AddFinalizer(obj interface{}) (bool, error) {
 	originWfr, ok := obj.(*v1alpha1.WorkflowRun)
 	if !ok {
 		log.WithField("obj", obj).Warning("Expect WorkflowRun, got unknown type resource")
-		return fmt.Errorf("unknown resource type")
+		return false, fmt.Errorf("unknown resource type")
 	}
 
 	if sets.NewString(originWfr.Finalizers...).Has(finalizerWorkflowRun) {
-		return nil
+		return false, nil
 	}
 
 	log.WithField("name", originWfr.Name).Debug("Start to add finalizer for workflowRun")
@@ -187,7 +187,7 @@ func (h *Handler) AddFinalizer(obj interface{}) error {
 	wfr := originWfr.DeepCopy()
 	wfr.ObjectMeta.Finalizers = append(wfr.ObjectMeta.Finalizers, finalizerWorkflowRun)
 	_, err := h.Client.CycloneV1alpha1().WorkflowRuns(wfr.Namespace).Update(context.TODO(), wfr, metav1.UpdateOptions{})
-	return err
+	return true, err
 }
 
 // HandleFinalizer does the finalizer key representing things.

--- a/pkg/workflow/controller/handlers/workflowtrigger/handler.go
+++ b/pkg/workflow/controller/handlers/workflowtrigger/handler.go
@@ -61,15 +61,15 @@ func (h *Handler) finalize(wft *v1alpha1.WorkflowTrigger) error {
 }
 
 // AddFinalizer adds a finalizer to the object and update the object to the Kubernetes.
-func (h *Handler) AddFinalizer(obj interface{}) error {
+func (h *Handler) AddFinalizer(obj interface{}) (bool, error) {
 	originWft, ok := obj.(*v1alpha1.WorkflowTrigger)
 	if !ok {
 		log.WithField("obj", obj).Warning("Expect WorkflowTrigger, got unknown type resource")
-		return fmt.Errorf("unknown resource type")
+		return false, fmt.Errorf("unknown resource type")
 	}
 
 	if sets.NewString(originWft.Finalizers...).Has(finalizerWorkflowTrigger) {
-		return nil
+		return false, nil
 	}
 
 	log.WithField("name", originWft.Name).Debug("Start to add finalizer for workflowTrigger")
@@ -77,7 +77,7 @@ func (h *Handler) AddFinalizer(obj interface{}) error {
 	wft := originWft.DeepCopy()
 	wft.ObjectMeta.Finalizers = append(wft.ObjectMeta.Finalizers, finalizerWorkflowTrigger)
 	_, err := h.client.CycloneV1alpha1().WorkflowTriggers(wft.Namespace).Update(context.TODO(), wft, metav1.UpdateOptions{})
-	return err
+	return true, err
 }
 
 // HandleFinalizer does the finalizer key representing things.

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -391,14 +391,14 @@ func (o *operator) Reconcile() (controller.Result, error) {
 		return res, fmt.Errorf("resolve overall status error: %v", err)
 	}
 	o.wfr.Status.Overall = *overall
-	err = o.Update()
-	if err != nil {
-		log.WithField("wfr", o.wfr.Name).Error("Update status error: ", err)
-		return res, err
-	}
 
 	// Return if no stages need to run.
 	if len(nextStages) == 0 {
+		err = o.Update()
+		if err != nil {
+			log.WithField("wfr", o.wfr.Name).Error("Update status error: ", err)
+			return res, err
+		}
 		return res, nil
 	}
 

--- a/pkg/workflow/workflowrun/workload.go
+++ b/pkg/workflow/workflowrun/workload.go
@@ -96,7 +96,7 @@ func (p *WorkloadProcessor) processPod() error {
 		return fmt.Errorf("create pod: %w", err)
 	}
 
-	log.WithField("wfr", p.wfr.Name).WithField("stg", p.stg.Name).Debug("Create pod for stage succeeded")
+	log.WithField("wfr", p.wfr.Name).WithField("stg", p.stg.Name).WithField("pod", po.Name).Debug("Create pod for stage succeeded")
 	p.wfrOper.GetRecorder().Eventf(p.wfr, corev1.EventTypeNormal, "StagePodCreated", "Create pod for stage '%s' succeeded", p.stg.Name)
 
 	go p.podEventWatcher.Work(p.stg.Name, po.Namespace, po.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What type of PR is this?**

/area cicd
/kind bug
<!--
Add one or more of the following kinds:
/kind api-change
/kind cleanup
/kind deprecation
/kind documentation
/kind test
/kind feature
/kind regression
/kind upgrade
/kind denpendency
-->

**What this PR does / why we need it**:

Currently a workflowRun could be updated 3 times during reconciliation, which causes subtle bug, for instance the operator begins to reconcile before receiving the 3rd update from the API server.

This PR makes sure the workflowRun controller return immediately after updating the workflowRun object.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: ensure workflowRun controller return immediately after updating
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
