### PR TITLE
fix(wfr): calculate overall status of wfr correctly

### DIFF
--- a/pkg/apis/cyclone/v1alpha1/workflow_run.go
+++ b/pkg/apis/cyclone/v1alpha1/workflow_run.go
@@ -170,6 +170,11 @@ type PodInfo struct {
 	Namespace string `json:"namespace"`
 }
 
+const (
+	// ReasonCreatePodError indicates WorkflowRun fails because it fails to create Pod.
+	ReasonCreatePodError = "CreatePodError"
+)
+
 // Status of a Stage in a WorkflowRun or the whole WorkflowRun.
 // +k8s:deepcopy-gen=true
 type Status struct {

--- a/pkg/workflow/workflowrun/operator.go
+++ b/pkg/workflow/workflowrun/operator.go
@@ -290,7 +290,8 @@ func (o *operator) OverallStatus() (*v1alpha1.Status, error) {
 		case v1alpha1.StatusWaiting:
 			waiting = true
 		case v1alpha1.StatusFailed:
-			err = err || !IsTrivial(o.wf, stage)
+			trivial := status.Status.Reason != v1alpha1.ReasonCreatePodError && IsTrivial(o.wf, stage)
+			err = err || !trivial
 		case v1alpha1.StatusPending:
 			pending = true
 		case v1alpha1.StatusSucceeded:

--- a/pkg/workflow/workflowrun/workload.go
+++ b/pkg/workflow/workflowrun/workload.go
@@ -97,7 +97,7 @@ func (p *WorkloadProcessor) processPod() error {
 		p.wfrOper.GetRecorder().Eventf(p.wfr, corev1.EventTypeWarning, "StagePodCreated", "Create pod for stage '%s' error: %v", p.stg.Name, err)
 		p.wfrOper.UpdateStageStatus(p.stg.Name, &v1alpha1.Status{
 			Phase:              v1alpha1.StatusFailed,
-			Reason:             "CreatePodError",
+			Reason:             v1alpha1.ReasonCreatePodError,
 			LastTransitionTime: metav1.Time{Time: time.Now()},
 			Message:            fmt.Sprintf("Failed to create pod: %v", err),
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What type of PR is this?**

/area cicd
/kind bug


**What this PR does / why we need it**:
Currently if a stage is trivial and fails because of failing to create pod, the controller would still consider it as succeeded. This PR fix this behavior.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @zhujian7 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
